### PR TITLE
Fixed name of AFCCTRL register and added a few defines.

### DIFF
--- a/RFM69registers.h
+++ b/RFM69registers.h
@@ -21,7 +21,7 @@
 #define REG_FRFMID			  0x08
 #define REG_FRFLSB		  	0x09
 #define REG_OSC1		  	  0x0A
-#define REG_REGAFCCTRL		0x0B
+#define REG_AFCCTRL   		0x0B
 #define REG_LOWBAT			  0x0C
 #define REG_LISTEN1			  0x0D
 #define REG_LISTEN2			  0x0E


### PR DESCRIPTION
RegAfcCtrl (0x0B) was incorrectly named RegOsc2.  Fixed that and added a couple other defines that are useful for me trying to get a Moteino talking to my weather station.  Hope you can merget these.
