### PR TITLE
Don't call receiveBegin() for every call to receiveDone().

### DIFF
--- a/RFM69.cpp
+++ b/RFM69.cpp
@@ -47,6 +47,7 @@ bool RFM69::initialize(byte freqBand, byte nodeID, byte networkID)
     // RXBW defaults are { REG_RXBW, RF_RXBW_DCCFREQ_010 | RF_RXBW_MANT_24 | RF_RXBW_EXP_5} (RxBw: 10.4khz)
     /* 0x19 */ { REG_RXBW, RF_RXBW_DCCFREQ_010 | RF_RXBW_MANT_16 | RF_RXBW_EXP_2 }, //(BitRate < 2 * RxBw)
     /* 0x25 */ { REG_DIOMAPPING1, RF_DIOMAPPING1_DIO0_01 }, //DIO0 is the only IRQ we're using
+    /* 0x28 */ { REG_IRQFLAGS2, RF_IRQFLAGS2_FIFOOVERRUN }, // Writing to this bit ensures the FIFO & status flags are reset
     /* 0x29 */ { REG_RSSITHRESH, 220 }, //must be set to dBm = (-Sensitivity / 2) - default is 0xE4=228 so -114dBm
     ///* 0x2d */ { REG_PREAMBLELSB, RF_PREAMBLESIZE_LSB_VALUE } // default 3 preamble bytes 0xAAAAAA
     /* 0x2e */ { REG_SYNCCONFIG, RF_SYNC_ON | RF_SYNC_FIFOFILL_AUTO | RF_SYNC_SIZE_2 | RF_SYNC_TOL_0 },


### PR DESCRIPTION
Not sure if the comment on this commit will automagically appear or not, so I'll cut and paste it here:

A Serial.print() at the very end of receiveBegin() showed that it was being called every single time receiveDone was called, even if we were already receiving. This was creating all kinds of SPI traffic to the radio every time. Now receiveBegin is only called when necessary. The intermittent packet errors I was seeing in the reception of data from my weather station are gone except for the reception of the very first packet - looks to be a different issue.
