### PR TITLE
Allow the use of other SPI slaves

### DIFF
--- a/RFM69.h
+++ b/RFM69.h
@@ -41,6 +41,7 @@ class RFM69 {
     static volatile byte ACK_RECEIVED; /// Should be polled immediately after sending a packet with ACK request
     static volatile int RSSI; //most accurate RSSI during reception (closest to the reception)
     static volatile byte _mode; //should be protected?
+    static volatile boolean dataReceived;	
     
     RFM69(byte slaveSelectPin=SPI_CS, byte interruptPin=RF69_IRQ_PIN, bool isRFM69HW=false) {
       _slaveSelectPin = slaveSelectPin;
@@ -89,6 +90,7 @@ class RFM69 {
     bool _isRFM69HW;
 
     void receiveBegin();
+    void readReceivedData();
     void setMode(byte mode);
     void setHighPowerRegs(bool onOff);
     void select();


### PR DESCRIPTION
The library does not allow the use of multiple SPI slaves:
When the interrupt is fired while SPI access are underway on another slave, there is unpredictable behavior.
This is due to SPI use in interrupt : rfm69 CS is enabled while another one is already selected (2 slaves simultaneously selected)

I solved this issue by moving the SPI reading in the 'receiveDone' function (used outside the interrupt), and adding a flag 'dataReceived'
