### PR TITLE
Fix wireless programming encryption

### DIFF
--- a/Examples/WirelessProgramming_node/WirelessProgramming_node.ino
+++ b/Examples/WirelessProgramming_node/WirelessProgramming_node.ino
@@ -53,7 +53,7 @@ void setup(){
   pinMode(LED, OUTPUT);
   Serial.begin(SERIAL_BAUD);
   radio.initialize(FREQUENCY,MYID,NETWORKID);
-  //radio.encrypt(ENCRYPTKEY); //OPTIONAL
+  radio.encrypt(ENCRYPTKEY); //OPTIONAL
 #ifdef IS_RFM69HW
   radio.setHighPower(); //only for RFM69HW!
 #endif


### PR DESCRIPTION
Previously, the wireless programming gateway sketch and the node sketch did not have the same encryption "setting." The gateway wanted to use encryption but the node had the line commented out. Uncommenting this line allows wireless programming to work out of the box.
