### PR TITLE
Fixed network hang in sendACK and some other improvements

### DIFF
--- a/RFM69.cpp
+++ b/RFM69.cpp
@@ -192,7 +192,7 @@ bool RFM69::canSend()
 void RFM69::send(byte toAddress, const void* buffer, byte bufferSize, bool requestACK)
 {
   writeReg(REG_PACKETCONFIG2, (readReg(REG_PACKETCONFIG2) & 0xFB) | RF_PACKET2_RXRESTART); // avoid RX deadlocks
-  long now = millis();
+  unsigned long now = millis();
   while (!canSend() && millis()-now < RF69_CSMA_LIMIT_MS) receiveDone();
   sendFrame(toAddress, buffer, bufferSize, requestACK, false);
 }
@@ -204,7 +204,7 @@ void RFM69::send(byte toAddress, const void* buffer, byte bufferSize, bool reque
 // requires user action to read the received data and decide what to do with it
 // replies usually take only 5-8ms at 50kbps@915Mhz
 bool RFM69::sendWithRetry(byte toAddress, const void* buffer, byte bufferSize, byte retries, byte retryWaitTime) {
-  long sentTime;
+  unsigned long sentTime;
   for (byte i=0; i<=retries; i++)
   {
     send(toAddress, buffer, bufferSize, true);
@@ -239,7 +239,7 @@ void RFM69::sendACK(const void* buffer, byte bufferSize) {
   setMode(RF69_MODE_RX); //Switching from STANDBY to RX before TX
   int _RSSI = RSSI; //save payload received RSSI value
   bool canSendACK = false; 
-  long now = millis();
+  unsigned long now = millis();
   while (millis()-now < ACK_CSMA_LIMIT_MS) //wait for free network the same time as sender waits for ACK
   {
     if (readRSSI() < CSMA_LIMIT) //if signal weaker than -90dBm(CSMA_LIMIT) is detected channel should be free

--- a/RFM69.cpp
+++ b/RFM69.cpp
@@ -283,7 +283,8 @@ void RFM69::sendFrame(byte toAddress, const void* buffer, byte bufferSize, bool 
 
 	/* no need to wait for transmit mode to be ready since its handled by the radio */
 	setMode(RF69_MODE_TX);
-	while (digitalRead(_interruptPin) == 0); //wait for DIO0 to turn HIGH signalling transmission finish
+	unsigned long now = millis();
+	while (digitalRead(_interruptPin) == 0 && millis()-now < RF69_TX_LIMIT_MS); //wait for DIO0 to turn HIGH signalling transmission finish no longer than 1000ms
   //while (readReg(REG_IRQFLAGS2) & RF_IRQFLAGS2_PACKETSENT == 0x00); // Wait for ModeReady
   setMode(RF69_MODE_STANDBY);
 }

--- a/RFM69.cpp
+++ b/RFM69.cpp
@@ -300,7 +300,7 @@ void RFM69::interruptHandler() {
     PAYLOADLEN = SPI.transfer(0);
     PAYLOADLEN = PAYLOADLEN > 66 ? 66 : PAYLOADLEN; //precaution
     TARGETID = SPI.transfer(0);
-    if(!(_promiscuousMode || TARGETID==_address || TARGETID==RF69_BROADCAST_ADDR)) //match this node's address, or broadcast address or anything in promiscuous mode
+    if(!(_promiscuousMode || TARGETID==_address || TARGETID==RF69_BROADCAST_ADDR || PAYLOADLEN < 3)) //match this node's address, or broadcast address or anything in promiscuous mode, and is payload valid?
     {
       PAYLOADLEN = 0;
       unselect();

--- a/RFM69.h
+++ b/RFM69.h
@@ -65,6 +65,7 @@
 #define COURSE_TEMP_COEF    -90 // puts the temperature reading in the ballpark, user can fine tune the returned value
 #define RF69_BROADCAST_ADDR 255
 #define RF69_CSMA_LIMIT_MS 1000
+#define ACK_CSMA_LIMIT_MS    40
 #define RF69_FSTEP 61.03515625 // == FXOSC/2^19 = 32mhz/2^19 (p13 in DS)
 
 class RFM69 {
@@ -94,7 +95,7 @@ class RFM69 {
     void setNetwork(byte networkID);
     bool canSend();
     void send(byte toAddress, const void* buffer, byte bufferSize, bool requestACK=false);
-    bool sendWithRetry(byte toAddress, const void* buffer, byte bufferSize, byte retries=2, byte retryWaitTime=40); //40ms roundtrip req for  61byte packets
+    bool sendWithRetry(byte toAddress, const void* buffer, byte bufferSize, byte retries=2, byte retryWaitTime=ACK_CSMA_LIMIT_MS); //40ms roundtrip req for  61byte packets
     bool receiveDone();
     bool ACKReceived(byte fromNodeID);
     bool ACKRequested();

--- a/RFM69.h
+++ b/RFM69.h
@@ -65,6 +65,7 @@
 #define COURSE_TEMP_COEF    -90 // puts the temperature reading in the ballpark, user can fine tune the returned value
 #define RF69_BROADCAST_ADDR 255
 #define RF69_CSMA_LIMIT_MS 1000
+#define RF69_TX_LIMIT_MS   1000
 #define ACK_CSMA_LIMIT_MS    40
 #define RF69_FSTEP 61.03515625 // == FXOSC/2^19 = 32mhz/2^19 (p13 in DS)
 


### PR DESCRIPTION
Improvements after noticed hanged network:
- fixed sendACK
- fixed millis() datatype, transmit timeout and malformed payload (by Jeremy Gilbert suggestions, see https://github.com/jgilbert20/RFM69)

Details see https://lowpowerlab.com/forum/index.php/topic,736.30.html
