### PR TITLE
Unify indentation (from TAB to two spaces)

### DIFF
--- a/Examples/OLEDMote/OLEDMote.ino
+++ b/Examples/OLEDMote/OLEDMote.ino
@@ -59,7 +59,7 @@
 #define BUTTON_PIN    3 //user button on interrupt 1
 
 RFM69 radio;
-U8GLIB_SSD1306_128X64 u8g(U8G_I2C_OPT_NONE);	// I2C / TWI SSD1306 OLED 128x64
+U8GLIB_SSD1306_128X64 u8g(U8G_I2C_OPT_NONE); // I2C / TWI SSD1306 OLED 128x64
 bool promiscuousMode = true; //set to 'true' to sniff all packets on the same network
 
 void setup() {

--- a/Examples/Struct_receive/Struct_receive.ino
+++ b/Examples/Struct_receive/Struct_receive.ino
@@ -14,7 +14,7 @@ RFM69 radio;
 SPIFlash flash(8, 0xEF30); //EF40 for 16mbit windbond chip
 bool promiscuousMode = false; //set to 'true' to sniff all packets on the same network
 
-typedef struct {		
+typedef struct {
   int           nodeId; //store this nodeId
   unsigned long uptime; //uptime in ms
   float         temp;   //temperature maybe?
@@ -88,10 +88,10 @@ void loop() {
     Serial.print('[');Serial.print(radio.SENDERID, DEC);Serial.print("] ");
     Serial.print(" [RX_RSSI:");Serial.print(radio.readRSSI());Serial.print("]");
     if (promiscuousMode)
-	{
+    {
       Serial.print("to [");Serial.print(radio.TARGETID, DEC);Serial.print("] ");
     }
-	
+
     if (radio.DATALEN != sizeof(Payload))
       Serial.print("Invalid payload received, not matching Payload struct!");
     else

--- a/Examples/Struct_send/Struct_send.ino
+++ b/Examples/Struct_send/Struct_send.ino
@@ -17,7 +17,7 @@ boolean requestACK = false;
 SPIFlash flash(8, 0xEF30); //EF40 for 16mbit windbond chip
 RFM69 radio;
 
-typedef struct {		
+typedef struct {
   int           nodeId; //store this nodeId
   unsigned long uptime; //uptime in ms
   float         temp;   //temperature maybe?

--- a/RFM69.cpp
+++ b/RFM69.cpp
@@ -33,14 +33,14 @@
 #include <SPI.h>
 
 volatile byte RFM69::DATA[RF69_MAX_DATA_LEN];
-volatile byte RFM69::_mode;       // current transceiver state
+volatile byte RFM69::_mode;        // current transceiver state
 volatile byte RFM69::DATALEN;
 volatile byte RFM69::SENDERID;
-volatile byte RFM69::TARGETID; //should match _address
+volatile byte RFM69::TARGETID;     // should match _address
 volatile byte RFM69::PAYLOADLEN;
 volatile byte RFM69::ACK_REQUESTED;
-volatile byte RFM69::ACK_RECEIVED; /// Should be polled immediately after sending a packet with ACK request
-volatile int RFM69::RSSI; //most accurate RSSI during reception (closest to the reception)
+volatile byte RFM69::ACK_RECEIVED; // should be polled immediately after sending a packet with ACK request
+volatile int RFM69::RSSI;          // most accurate RSSI during reception (closest to the reception)
 RFM69* RFM69::selfPointer;
 
 bool RFM69::initialize(byte freqBand, byte nodeID, byte networkID)
@@ -48,10 +48,10 @@ bool RFM69::initialize(byte freqBand, byte nodeID, byte networkID)
   const byte CONFIG[][2] =
   {
     /* 0x01 */ { REG_OPMODE, RF_OPMODE_SEQUENCER_ON | RF_OPMODE_LISTEN_OFF | RF_OPMODE_STANDBY },
-    /* 0x02 */ { REG_DATAMODUL, RF_DATAMODUL_DATAMODE_PACKET | RF_DATAMODUL_MODULATIONTYPE_FSK | RF_DATAMODUL_MODULATIONSHAPING_00 }, //no shaping
-    /* 0x03 */ { REG_BITRATEMSB, RF_BITRATEMSB_55555}, //default:4.8 KBPS
+    /* 0x02 */ { REG_DATAMODUL, RF_DATAMODUL_DATAMODE_PACKET | RF_DATAMODUL_MODULATIONTYPE_FSK | RF_DATAMODUL_MODULATIONSHAPING_00 }, // no shaping
+    /* 0x03 */ { REG_BITRATEMSB, RF_BITRATEMSB_55555}, // default:4.8 KBPS
     /* 0x04 */ { REG_BITRATELSB, RF_BITRATELSB_55555},
-    /* 0x05 */ { REG_FDEVMSB, RF_FDEVMSB_50000}, //default:5khz, (FDEV + BitRate/2 <= 500Khz)
+    /* 0x05 */ { REG_FDEVMSB, RF_FDEVMSB_50000}, // default:5khz, (FDEV + BitRate/2 <= 500Khz)
     /* 0x06 */ { REG_FDEVLSB, RF_FDEVLSB_50000},
 
     /* 0x07 */ { REG_FRFMSB, (freqBand==RF69_315MHZ ? RF_FRFMSB_315 : (freqBand==RF69_433MHZ ? RF_FRFMSB_433 : (freqBand==RF69_868MHZ ? RF_FRFMSB_868 : RF_FRFMSB_915))) },
@@ -64,24 +64,24 @@ bool RFM69::initialize(byte freqBand, byte nodeID, byte networkID)
     // +17dBm formula: Pout=-14+OutputPower (with PA1 and PA2)**
     // +20dBm formula: Pout=-11+OutputPower (with PA1 and PA2)** and high power PA settings (section 3.3.7 in datasheet)
     ///* 0x11 */ { REG_PALEVEL, RF_PALEVEL_PA0_ON | RF_PALEVEL_PA1_OFF | RF_PALEVEL_PA2_OFF | RF_PALEVEL_OUTPUTPOWER_11111},
-    ///* 0x13 */ { REG_OCP, RF_OCP_ON | RF_OCP_TRIM_95 }, //over current protection (default is 95mA)
+    ///* 0x13 */ { REG_OCP, RF_OCP_ON | RF_OCP_TRIM_95 }, // over current protection (default is 95mA)
 
     // RXBW defaults are { REG_RXBW, RF_RXBW_DCCFREQ_010 | RF_RXBW_MANT_24 | RF_RXBW_EXP_5} (RxBw: 10.4khz)
-    /* 0x19 */ { REG_RXBW, RF_RXBW_DCCFREQ_010 | RF_RXBW_MANT_16 | RF_RXBW_EXP_2 }, //(BitRate < 2 * RxBw)
-    //for BR-19200: //* 0x19 */ { REG_RXBW, RF_RXBW_DCCFREQ_010 | RF_RXBW_MANT_24 | RF_RXBW_EXP_3 },
-    /* 0x25 */ { REG_DIOMAPPING1, RF_DIOMAPPING1_DIO0_01 }, //DIO0 is the only IRQ we're using
-    /* 0x29 */ { REG_RSSITHRESH, 220 }, //must be set to dBm = (-Sensitivity / 2) - default is 0xE4=228 so -114dBm
+    /* 0x19 */ { REG_RXBW, RF_RXBW_DCCFREQ_010 | RF_RXBW_MANT_16 | RF_RXBW_EXP_2 }, // (BitRate < 2 * RxBw)
+    //for BR-19200: /* 0x19 */ { REG_RXBW, RF_RXBW_DCCFREQ_010 | RF_RXBW_MANT_24 | RF_RXBW_EXP_3 },
+    /* 0x25 */ { REG_DIOMAPPING1, RF_DIOMAPPING1_DIO0_01 }, // DIO0 is the only IRQ we're using
+    /* 0x29 */ { REG_RSSITHRESH, 220 }, // must be set to dBm = (-Sensitivity / 2) - default is 0xE4=228 so -114dBm
     ///* 0x2d */ { REG_PREAMBLELSB, RF_PREAMBLESIZE_LSB_VALUE } // default 3 preamble bytes 0xAAAAAA
     /* 0x2e */ { REG_SYNCCONFIG, RF_SYNC_ON | RF_SYNC_FIFOFILL_AUTO | RF_SYNC_SIZE_2 | RF_SYNC_TOL_0 },
-    /* 0x2f */ { REG_SYNCVALUE1, 0x2D },      //attempt to make this compatible with sync1 byte of RFM12B lib
-    /* 0x30 */ { REG_SYNCVALUE2, networkID }, //NETWORK ID
+    /* 0x2f */ { REG_SYNCVALUE1, 0x2D },      // attempt to make this compatible with sync1 byte of RFM12B lib
+    /* 0x30 */ { REG_SYNCVALUE2, networkID }, // NETWORK ID
     /* 0x37 */ { REG_PACKETCONFIG1, RF_PACKET1_FORMAT_VARIABLE | RF_PACKET1_DCFREE_OFF | RF_PACKET1_CRC_ON | RF_PACKET1_CRCAUTOCLEAR_ON | RF_PACKET1_ADRSFILTERING_OFF },
-    /* 0x38 */ { REG_PAYLOADLENGTH, 66 }, //in variable length mode: the max frame size, not used in TX
-    //* 0x39 */ { REG_NODEADRS, nodeID }, //turned off because we're not using address filtering
-    /* 0x3C */ { REG_FIFOTHRESH, RF_FIFOTHRESH_TXSTART_FIFONOTEMPTY | RF_FIFOTHRESH_VALUE }, //TX on FIFO not empty
-    /* 0x3d */ { REG_PACKETCONFIG2, RF_PACKET2_RXRESTARTDELAY_2BITS | RF_PACKET2_AUTORXRESTART_ON | RF_PACKET2_AES_OFF }, //RXRESTARTDELAY must match transmitter PA ramp-down time (bitrate dependent)
-    //for BR-19200: //* 0x3d */ { REG_PACKETCONFIG2, RF_PACKET2_RXRESTARTDELAY_NONE | RF_PACKET2_AUTORXRESTART_ON | RF_PACKET2_AES_OFF }, //RXRESTARTDELAY must match transmitter PA ramp-down time (bitrate dependent)
-    //* 0x6F */ { REG_TESTDAGC, RF_DAGC_CONTINUOUS }, // run DAGC continuously in RX mode
+    /* 0x38 */ { REG_PAYLOADLENGTH, 66 }, // in variable length mode: the max frame size, not used in TX
+    ///* 0x39 */ { REG_NODEADRS, nodeID }, // turned off because we're not using address filtering
+    /* 0x3C */ { REG_FIFOTHRESH, RF_FIFOTHRESH_TXSTART_FIFONOTEMPTY | RF_FIFOTHRESH_VALUE }, // TX on FIFO not empty
+    /* 0x3d */ { REG_PACKETCONFIG2, RF_PACKET2_RXRESTARTDELAY_2BITS | RF_PACKET2_AUTORXRESTART_ON | RF_PACKET2_AES_OFF }, // RXRESTARTDELAY must match transmitter PA ramp-down time (bitrate dependent)
+    //for BR-19200: /* 0x3d */ { REG_PACKETCONFIG2, RF_PACKET2_RXRESTARTDELAY_NONE | RF_PACKET2_AUTORXRESTART_ON | RF_PACKET2_AES_OFF }, // RXRESTARTDELAY must match transmitter PA ramp-down time (bitrate dependent)
+    ///* 0x6F */ { REG_TESTDAGC, RF_DAGC_CONTINUOUS }, // run DAGC continuously in RX mode
     /* 0x6F */ { REG_TESTDAGC, RF_DAGC_IMPROVED_LOWBETA0 }, // run DAGC continuously in RX mode, recommended default for AfcLowBetaOn=0
     {255, 0}
   };
@@ -99,9 +99,9 @@ bool RFM69::initialize(byte freqBand, byte nodeID, byte networkID)
   // Disable it during initialization so we always start from a known state.
   encrypt(0);
 
-  setHighPower(_isRFM69HW); //called regardless if it's a RFM69W or RFM69HW
+  setHighPower(_isRFM69HW); // called regardless if it's a RFM69W or RFM69HW
   setMode(RF69_MODE_STANDBY);
-  while ((readReg(REG_IRQFLAGS1) & RF_IRQFLAGS1_MODEREADY) == 0x00); // Wait for ModeReady
+  while ((readReg(REG_IRQFLAGS1) & RF_IRQFLAGS1_MODEREADY) == 0x00); // wait for ModeReady
   attachInterrupt(_interruptNum, RFM69::isr0, RISING);
 
   selfPointer = this;
@@ -109,17 +109,17 @@ bool RFM69::initialize(byte freqBand, byte nodeID, byte networkID)
   return true;
 }
 
-//return the frequency (in Hz)
+// return the frequency (in Hz)
 uint32_t RFM69::getFrequency()
 {
   return RF69_FSTEP * (((uint32_t)readReg(REG_FRFMSB)<<16) + ((uint16_t)readReg(REG_FRFMID)<<8) + readReg(REG_FRFLSB));
 }
 
-//set the frequency (in Hz)
+// set the frequency (in Hz)
 void RFM69::setFrequency(uint32_t freqHz)
 {
-  //TODO: p38 hopping sequence may need to be followed in some cases
-  freqHz /= RF69_FSTEP; //divide down by FSTEP to get FRF
+  // TODO: p38 hopping sequence may need to be followed in some cases
+  freqHz /= RF69_FSTEP; // divide down by FSTEP to get FRF
   writeReg(REG_FRFMSB, freqHz >> 16);
   writeReg(REG_FRFMID, freqHz >> 8);
   writeReg(REG_FRFLSB, freqHz);
@@ -127,7 +127,7 @@ void RFM69::setFrequency(uint32_t freqHz)
 
 void RFM69::setMode(byte newMode)
 {
-  if (newMode == _mode) return; //TODO: can remove this?
+  if (newMode == _mode) return; // TODO: can remove this?
 
   switch (newMode) {
     case RF69_MODE_TX:
@@ -152,7 +152,7 @@ void RFM69::setMode(byte newMode)
 
   // we are using packet mode, so this check is not really needed
   // but waiting for mode ready is necessary when going from sleep because the FIFO may not be immediately available from previous mode
-  while (_mode == RF69_MODE_SLEEP && (readReg(REG_IRQFLAGS1) & RF_IRQFLAGS1_MODEREADY) == 0x00); // Wait for ModeReady
+  while (_mode == RF69_MODE_SLEEP && (readReg(REG_IRQFLAGS1) & RF_IRQFLAGS1_MODEREADY) == 0x00); // wait for ModeReady
 
   _mode = newMode;
 }
@@ -182,7 +182,7 @@ void RFM69::setPowerLevel(byte powerLevel)
 
 bool RFM69::canSend()
 {
-  if (_mode == RF69_MODE_RX && PAYLOADLEN == 0 && readRSSI() < CSMA_LIMIT) //if signal stronger than -100dBm is detected assume channel activity
+  if (_mode == RF69_MODE_RX && PAYLOADLEN == 0 && readRSSI() < CSMA_LIMIT) // if signal stronger than -100dBm is detected assume channel activity
   {
     setMode(RF69_MODE_STANDBY);
     return true;
@@ -201,12 +201,12 @@ void RFM69::send(byte toAddress, const void* buffer, byte bufferSize, bool reque
 // to increase the chance of getting a packet across, call this function instead of send
 // and it handles all the ACK requesting/retrying for you :)
 // The only twist is that you have to manually listen to ACK requests on the other side and send back the ACKs
-// The reason for the semi-automaton is that the lib is ingterrupt driven and
+// The reason for the semi-automaton is that the lib is interrupt driven and
 // requires user action to read the received data and decide what to do with it
 // replies usually take only 5-8ms at 50kbps@915Mhz
 bool RFM69::sendWithRetry(byte toAddress, const void* buffer, byte bufferSize, byte retries, byte retryWaitTime) {
   unsigned long sentTime;
-  for (byte i=0; i<=retries; i++)
+  for (byte i = 0; i <= retries; i++)
   {
     send(toAddress, buffer, bufferSize, true);
     sentTime = millis();
@@ -223,44 +223,44 @@ bool RFM69::sendWithRetry(byte toAddress, const void* buffer, byte bufferSize, b
   return false;
 }
 
-/// Should be polled immediately after sending a packet with ACK request
+// should be polled immediately after sending a packet with ACK request
 bool RFM69::ACKReceived(byte fromNodeID) {
   if (receiveDone())
     return (SENDERID == fromNodeID || fromNodeID == RF69_BROADCAST_ADDR) && ACK_RECEIVED;
   return false;
 }
 
-//check whether an ACK was requested in the last received packet (non-broadcasted packet)
+// check whether an ACK was requested in the last received packet (non-broadcasted packet)
 bool RFM69::ACKRequested() {
   return ACK_REQUESTED && (TARGETID != RF69_BROADCAST_ADDR);
 }
 
-/// Should be called immediately after reception in case sender wants ACK
+// should be called immediately after reception in case sender wants ACK
 void RFM69::sendACK(const void* buffer, byte bufferSize) {
   byte sender = SENDERID;
-  int _RSSI = RSSI; //save payload received RSSI value
+  int _RSSI = RSSI; // save payload received RSSI value
   writeReg(REG_PACKETCONFIG2, (readReg(REG_PACKETCONFIG2) & 0xFB) | RF_PACKET2_RXRESTART); // avoid RX deadlocks
   unsigned long now = millis();
   while (!canSend() && millis()-now < RF69_CSMA_LIMIT_MS) receiveDone();
   sendFrame(sender, buffer, bufferSize, false, true);
-  RSSI = _RSSI; //restore payload RSSI
+  RSSI = _RSSI; // restore payload RSSI
 }
 
 void RFM69::sendFrame(byte toAddress, const void* buffer, byte bufferSize, bool requestACK, bool sendACK)
 {
-  setMode(RF69_MODE_STANDBY); //turn off receiver to prevent reception while filling fifo
-  while ((readReg(REG_IRQFLAGS1) & RF_IRQFLAGS1_MODEREADY) == 0x00); // Wait for ModeReady
+  setMode(RF69_MODE_STANDBY); // turn off receiver to prevent reception while filling fifo
+  while ((readReg(REG_IRQFLAGS1) & RF_IRQFLAGS1_MODEREADY) == 0x00); // wait for ModeReady
   writeReg(REG_DIOMAPPING1, RF_DIOMAPPING1_DIO0_00); // DIO0 is "Packet Sent"
   if (bufferSize > RF69_MAX_DATA_LEN) bufferSize = RF69_MAX_DATA_LEN;
 
-  //write to FIFO
+  // write to FIFO
   select();
   SPI.transfer(REG_FIFO | 0x80);
   SPI.transfer(bufferSize + 3);
   SPI.transfer(toAddress);
   SPI.transfer(_address);
 
-  //control byte
+  // control byte
   if (sendACK)
     SPI.transfer(0x80);
   else if (requestACK)
@@ -274,8 +274,8 @@ void RFM69::sendFrame(byte toAddress, const void* buffer, byte bufferSize, bool 
   /* no need to wait for transmit mode to be ready since its handled by the radio */
   setMode(RF69_MODE_TX);
   unsigned long txStart = millis();
-  while (digitalRead(_interruptPin) == 0 && millis()-txStart < RF69_TX_LIMIT_MS); //wait for DIO0 to turn HIGH signalling transmission finish
-  //while (readReg(REG_IRQFLAGS2) & RF_IRQFLAGS2_PACKETSENT == 0x00); // Wait for ModeReady
+  while (digitalRead(_interruptPin) == 0 && millis()-txStart < RF69_TX_LIMIT_MS); // wait for DIO0 to turn HIGH signalling transmission finish
+  //while (readReg(REG_IRQFLAGS2) & RF_IRQFLAGS2_PACKETSENT == 0x00); // wait for ModeReady
   setMode(RF69_MODE_STANDBY);
 }
 
@@ -289,10 +289,10 @@ void RFM69::interruptHandler() {
     select();
     SPI.transfer(REG_FIFO & 0x7f);
     PAYLOADLEN = SPI.transfer(0);
-    PAYLOADLEN = PAYLOADLEN > 66 ? 66 : PAYLOADLEN; //precaution
+    PAYLOADLEN = PAYLOADLEN > 66 ? 66 : PAYLOADLEN; // precaution
     TARGETID = SPI.transfer(0);
-    if(!(_promiscuousMode || TARGETID==_address || TARGETID==RF69_BROADCAST_ADDR) //match this node's address, or broadcast address or anything in promiscuous mode
-       || PAYLOADLEN < 3) //address situation could receive packets that are malformed and don't fit this libraries extra fields
+    if(!(_promiscuousMode || TARGETID == _address || TARGETID == RF69_BROADCAST_ADDR) // match this node's address, or broadcast address or anything in promiscuous mode
+       || PAYLOADLEN < 3) // address situation could receive packets that are malformed and don't fit this libraries extra fields
     {
       PAYLOADLEN = 0;
       unselect();
@@ -305,14 +305,14 @@ void RFM69::interruptHandler() {
     SENDERID = SPI.transfer(0);
     byte CTLbyte = SPI.transfer(0);
 
-    ACK_RECEIVED = CTLbyte & 0x80; //extract ACK-requested flag
-    ACK_REQUESTED = CTLbyte & 0x40; //extract ACK-received flag
+    ACK_RECEIVED = CTLbyte & 0x80; // extract ACK-received flag
+    ACK_REQUESTED = CTLbyte & 0x40; // extract ACK-requested flag
 
-    for (byte i= 0; i < DATALEN; i++)
+    for (byte i = 0; i < DATALEN; i++)
     {
       DATA[i] = SPI.transfer(0);
     }
-    if (DATALEN<RF69_MAX_DATA_LEN) DATA[DATALEN]=0; //add null at end of string
+    if (DATALEN<RF69_MAX_DATA_LEN) DATA[DATALEN] = 0; // add null at end of string
     unselect();
     setMode(RF69_MODE_RX);
   }
@@ -332,22 +332,22 @@ void RFM69::receiveBegin() {
   RSSI = 0;
   if (readReg(REG_IRQFLAGS2) & RF_IRQFLAGS2_PAYLOADREADY)
     writeReg(REG_PACKETCONFIG2, (readReg(REG_PACKETCONFIG2) & 0xFB) | RF_PACKET2_RXRESTART); // avoid RX deadlocks
-  writeReg(REG_DIOMAPPING1, RF_DIOMAPPING1_DIO0_01); //set DIO0 to "PAYLOADREADY" in receive mode
+  writeReg(REG_DIOMAPPING1, RF_DIOMAPPING1_DIO0_01); // set DIO0 to "PAYLOADREADY" in receive mode
   setMode(RF69_MODE_RX);
 }
 
 bool RFM69::receiveDone() {
-// ATOMIC_BLOCK(ATOMIC_FORCEON)
-// {
-  noInterrupts(); //re-enabled in unselect() via setMode() or via receiveBegin()
+//ATOMIC_BLOCK(ATOMIC_FORCEON)
+//{
+  noInterrupts(); // re-enabled in unselect() via setMode() or via receiveBegin()
   if (_mode == RF69_MODE_RX && PAYLOADLEN>0)
   {
-    setMode(RF69_MODE_STANDBY); //enables interrupts
+    setMode(RF69_MODE_STANDBY); // enables interrupts
     return true;
   }
-  else if (_mode == RF69_MODE_RX)  //already in RX no payload yet
+  else if (_mode == RF69_MODE_RX)  // already in RX no payload yet
   {
-    interrupts(); //explicitly re-enable interrupts
+    interrupts(); // explicitly re-enable interrupts
     return false;
   }
   receiveBegin();
@@ -360,11 +360,11 @@ bool RFM69::receiveDone() {
 // KEY HAS TO BE 16 bytes !!!
 void RFM69::encrypt(const char* key) {
   setMode(RF69_MODE_STANDBY);
-  if (key!=0)
+  if (key != 0)
   {
     select();
     SPI.transfer(REG_AESKEY1 | 0x80);
-    for (byte i = 0; i<16; i++)
+    for (byte i = 0; i < 16; i++)
       SPI.transfer(key[i]);
     unselect();
   }
@@ -375,9 +375,9 @@ int RFM69::readRSSI(bool forceTrigger) {
   int rssi = 0;
   if (forceTrigger)
   {
-    //RSSI trigger not needed if DAGC is in continuous mode
+    // RSSI trigger not needed if DAGC is in continuous mode
     writeReg(REG_RSSICONFIG, RF_RSSI_START);
-    while ((readReg(REG_RSSICONFIG) & RF_RSSI_DONE) == 0x00); // Wait for RSSI_Ready
+    while ((readReg(REG_RSSICONFIG) & RF_RSSI_DONE) == 0x00); // wait for RSSI_Ready
   }
   rssi = -readReg(REG_RSSIVALUE);
   rssi >>= 1;
@@ -401,23 +401,23 @@ void RFM69::writeReg(byte addr, byte value)
   unselect();
 }
 
-/// Select the transceiver
+// select the transceiver
 void RFM69::select() {
   noInterrupts();
-  //save current SPI settings
+  // save current SPI settings
   _SPCR = SPCR;
   _SPSR = SPSR;
-  //set RFM69 SPI settings
+  // set RFM69 SPI settings
   SPI.setDataMode(SPI_MODE0);
   SPI.setBitOrder(MSBFIRST);
-  SPI.setClockDivider(SPI_CLOCK_DIV4); //decided to slow down from DIV2 after SPI stalling in some instances, especially visible on mega1284p when RFM69 and FLASH chip both present
+  SPI.setClockDivider(SPI_CLOCK_DIV4); // decided to slow down from DIV2 after SPI stalling in some instances, especially visible on mega1284p when RFM69 and FLASH chip both present
   digitalWrite(_slaveSelectPin, LOW);
 }
 
-/// UNselect the transceiver chip
+// UNselect the transceiver chip
 void RFM69::unselect() {
   digitalWrite(_slaveSelectPin, HIGH);
-  //restore SPI settings to what they were before talking to RFM69
+  // restore SPI settings to what they were before talking to RFM69
   SPCR = _SPCR;
   SPSR = _SPSR;
   interrupts();
@@ -426,17 +426,17 @@ void RFM69::unselect() {
 // ON  = disable filtering to capture all frames on network
 // OFF = enable node+broadcast filtering to capture only frames sent to this/broadcast address
 void RFM69::promiscuous(bool onOff) {
-  _promiscuousMode=onOff;
+  _promiscuousMode = onOff;
   //writeReg(REG_PACKETCONFIG1, (readReg(REG_PACKETCONFIG1) & 0xF9) | (onOff ? RF_PACKET1_ADRSFILTERING_OFF : RF_PACKET1_ADRSFILTERING_NODEBROADCAST));
 }
 
 void RFM69::setHighPower(bool onOff) {
   _isRFM69HW = onOff;
   writeReg(REG_OCP, _isRFM69HW ? RF_OCP_OFF : RF_OCP_ON);
-  if (_isRFM69HW) //turning ON
-    writeReg(REG_PALEVEL, (readReg(REG_PALEVEL) & 0x1F) | RF_PALEVEL_PA1_ON | RF_PALEVEL_PA2_ON); //enable P1 & P2 amplifier stages
+  if (_isRFM69HW) // turning ON
+    writeReg(REG_PALEVEL, (readReg(REG_PALEVEL) & 0x1F) | RF_PALEVEL_PA1_ON | RF_PALEVEL_PA2_ON); // enable P1 & P2 amplifier stages
   else
-    writeReg(REG_PALEVEL, RF_PALEVEL_PA0_ON | RF_PALEVEL_PA1_OFF | RF_PALEVEL_PA2_OFF | _powerLevel); //enable P0 only
+    writeReg(REG_PALEVEL, RF_PALEVEL_PA0_ON | RF_PALEVEL_PA1_OFF | RF_PALEVEL_PA2_OFF | _powerLevel); // enable P0 only
 }
 
 void RFM69::setHighPowerRegs(bool onOff) {
@@ -449,7 +449,7 @@ void RFM69::setCS(byte newSPISlaveSelect) {
   pinMode(_slaveSelectPin, OUTPUT);
 }
 
-//for debugging
+// for debugging
 void RFM69::readAllRegs()
 {
   byte regVal;
@@ -457,7 +457,7 @@ void RFM69::readAllRegs()
   for (byte regAddr = 1; regAddr <= 0x4F; regAddr++)
   {
     select();
-    SPI.transfer(regAddr & 0x7f);  // send address + r/w bit
+    SPI.transfer(regAddr & 0x7f); // send address + r/w bit
     regVal = SPI.transfer(0);
     unselect();
 
@@ -470,12 +470,12 @@ void RFM69::readAllRegs()
   unselect();
 }
 
-byte RFM69::readTemperature(byte calFactor)  //returns centigrade
+byte RFM69::readTemperature(byte calFactor) // returns centigrade
 {
   setMode(RF69_MODE_STANDBY);
   writeReg(REG_TEMP1, RF_TEMP1_MEAS_START);
   while ((readReg(REG_TEMP1) & RF_TEMP1_MEAS_RUNNING));
-  return ~readReg(REG_TEMP2) + COURSE_TEMP_COEF + calFactor; //'complement'corrects the slope, rising temp = rising val
+  return ~readReg(REG_TEMP2) + COURSE_TEMP_COEF + calFactor; // 'complement'corrects the slope, rising temp = rising val
 } // COURSE_TEMP_COEF puts reading in the ballpark, user can add additional correction
 
 void RFM69::rcCalibration()

--- a/RFM69.cpp
+++ b/RFM69.cpp
@@ -57,7 +57,7 @@ bool RFM69::initialize(byte freqBand, byte nodeID, byte networkID)
     /* 0x07 */ { REG_FRFMSB, (freqBand==RF69_315MHZ ? RF_FRFMSB_315 : (freqBand==RF69_433MHZ ? RF_FRFMSB_433 : (freqBand==RF69_868MHZ ? RF_FRFMSB_868 : RF_FRFMSB_915))) },
     /* 0x08 */ { REG_FRFMID, (freqBand==RF69_315MHZ ? RF_FRFMID_315 : (freqBand==RF69_433MHZ ? RF_FRFMID_433 : (freqBand==RF69_868MHZ ? RF_FRFMID_868 : RF_FRFMID_915))) },
     /* 0x09 */ { REG_FRFLSB, (freqBand==RF69_315MHZ ? RF_FRFLSB_315 : (freqBand==RF69_433MHZ ? RF_FRFLSB_433 : (freqBand==RF69_868MHZ ? RF_FRFLSB_868 : RF_FRFLSB_915))) },
-    
+
     // looks like PA1 and PA2 are not implemented on RFM69W, hence the max output power is 13dBm
     // +17dBm and +20dBm are possible on RFM69HW
     // +13dBm formula: Pout=-18+OutputPower (with PA0 or PA1**)
@@ -65,7 +65,7 @@ bool RFM69::initialize(byte freqBand, byte nodeID, byte networkID)
     // +20dBm formula: Pout=-11+OutputPower (with PA1 and PA2)** and high power PA settings (section 3.3.7 in datasheet)
     ///* 0x11 */ { REG_PALEVEL, RF_PALEVEL_PA0_ON | RF_PALEVEL_PA1_OFF | RF_PALEVEL_PA2_OFF | RF_PALEVEL_OUTPUTPOWER_11111},
     ///* 0x13 */ { REG_OCP, RF_OCP_ON | RF_OCP_TRIM_95 }, //over current protection (default is 95mA)
-    
+
     // RXBW defaults are { REG_RXBW, RF_RXBW_DCCFREQ_010 | RF_RXBW_MANT_24 | RF_RXBW_EXP_5} (RxBw: 10.4khz)
     /* 0x19 */ { REG_RXBW, RF_RXBW_DCCFREQ_010 | RF_RXBW_MANT_16 | RF_RXBW_EXP_2 }, //(BitRate < 2 * RxBw)
     //for BR-19200: //* 0x19 */ { REG_RXBW, RF_RXBW_DCCFREQ_010 | RF_RXBW_MANT_24 | RF_RXBW_EXP_3 },
@@ -88,9 +88,9 @@ bool RFM69::initialize(byte freqBand, byte nodeID, byte networkID)
 
   pinMode(_slaveSelectPin, OUTPUT);
   SPI.begin();
-  
+
   do writeReg(REG_SYNCVALUE1, 0xaa); while (readReg(REG_SYNCVALUE1) != 0xaa);
-	do writeReg(REG_SYNCVALUE1, 0x55); while (readReg(REG_SYNCVALUE1) != 0x55);
+  do writeReg(REG_SYNCVALUE1, 0x55); while (readReg(REG_SYNCVALUE1) != 0x55);
 
   for (byte i = 0; CONFIG[i][0] != 255; i++)
     writeReg(CONFIG[i][0], CONFIG[i][1]);
@@ -101,7 +101,7 @@ bool RFM69::initialize(byte freqBand, byte nodeID, byte networkID)
 
   setHighPower(_isRFM69HW); //called regardless if it's a RFM69W or RFM69HW
   setMode(RF69_MODE_STANDBY);
-	while ((readReg(REG_IRQFLAGS1) & RF_IRQFLAGS1_MODEREADY) == 0x00); // Wait for ModeReady
+  while ((readReg(REG_IRQFLAGS1) & RF_IRQFLAGS1_MODEREADY) == 0x00); // Wait for ModeReady
   attachInterrupt(_interruptNum, RFM69::isr0, RISING);
 
   selfPointer = this;
@@ -127,34 +127,34 @@ void RFM69::setFrequency(uint32_t freqHz)
 
 void RFM69::setMode(byte newMode)
 {
-	if (newMode == _mode) return; //TODO: can remove this?
+  if (newMode == _mode) return; //TODO: can remove this?
 
-	switch (newMode) {
-		case RF69_MODE_TX:
-			writeReg(REG_OPMODE, (readReg(REG_OPMODE) & 0xE3) | RF_OPMODE_TRANSMITTER);
+  switch (newMode) {
+    case RF69_MODE_TX:
+      writeReg(REG_OPMODE, (readReg(REG_OPMODE) & 0xE3) | RF_OPMODE_TRANSMITTER);
       if (_isRFM69HW) setHighPowerRegs(true);
-			break;
-		case RF69_MODE_RX:
-			writeReg(REG_OPMODE, (readReg(REG_OPMODE) & 0xE3) | RF_OPMODE_RECEIVER);
+      break;
+    case RF69_MODE_RX:
+      writeReg(REG_OPMODE, (readReg(REG_OPMODE) & 0xE3) | RF_OPMODE_RECEIVER);
       if (_isRFM69HW) setHighPowerRegs(false);
-			break;
-		case RF69_MODE_SYNTH:
-			writeReg(REG_OPMODE, (readReg(REG_OPMODE) & 0xE3) | RF_OPMODE_SYNTHESIZER);
-			break;
-		case RF69_MODE_STANDBY:
-			writeReg(REG_OPMODE, (readReg(REG_OPMODE) & 0xE3) | RF_OPMODE_STANDBY);
-			break;
-		case RF69_MODE_SLEEP:
-			writeReg(REG_OPMODE, (readReg(REG_OPMODE) & 0xE3) | RF_OPMODE_SLEEP);
-			break;
-		default: return;
-	}
+      break;
+    case RF69_MODE_SYNTH:
+      writeReg(REG_OPMODE, (readReg(REG_OPMODE) & 0xE3) | RF_OPMODE_SYNTHESIZER);
+      break;
+    case RF69_MODE_STANDBY:
+      writeReg(REG_OPMODE, (readReg(REG_OPMODE) & 0xE3) | RF_OPMODE_STANDBY);
+      break;
+    case RF69_MODE_SLEEP:
+      writeReg(REG_OPMODE, (readReg(REG_OPMODE) & 0xE3) | RF_OPMODE_SLEEP);
+      break;
+    default: return;
+  }
 
-	// we are using packet mode, so this check is not really needed
+  // we are using packet mode, so this check is not really needed
   // but waiting for mode ready is necessary when going from sleep because the FIFO may not be immediately available from previous mode
-	while (_mode == RF69_MODE_SLEEP && (readReg(REG_IRQFLAGS1) & RF_IRQFLAGS1_MODEREADY) == 0x00); // Wait for ModeReady
+  while (_mode == RF69_MODE_SLEEP && (readReg(REG_IRQFLAGS1) & RF_IRQFLAGS1_MODEREADY) == 0x00); // Wait for ModeReady
 
-	_mode = newMode;
+  _mode = newMode;
 }
 
 void RFM69::sleep() {
@@ -164,12 +164,12 @@ void RFM69::sleep() {
 void RFM69::setAddress(byte addr)
 {
   _address = addr;
-	writeReg(REG_NODEADRS, _address);
+  writeReg(REG_NODEADRS, _address);
 }
 
 void RFM69::setNetwork(byte networkID)
 {
-	writeReg(REG_SYNCVALUE2, networkID);
+  writeReg(REG_SYNCVALUE2, networkID);
 }
 
 // set output power: 0=min, 31=max
@@ -249,32 +249,32 @@ void RFM69::sendACK(const void* buffer, byte bufferSize) {
 void RFM69::sendFrame(byte toAddress, const void* buffer, byte bufferSize, bool requestACK, bool sendACK)
 {
   setMode(RF69_MODE_STANDBY); //turn off receiver to prevent reception while filling fifo
-	while ((readReg(REG_IRQFLAGS1) & RF_IRQFLAGS1_MODEREADY) == 0x00); // Wait for ModeReady
+  while ((readReg(REG_IRQFLAGS1) & RF_IRQFLAGS1_MODEREADY) == 0x00); // Wait for ModeReady
   writeReg(REG_DIOMAPPING1, RF_DIOMAPPING1_DIO0_00); // DIO0 is "Packet Sent"
   if (bufferSize > RF69_MAX_DATA_LEN) bufferSize = RF69_MAX_DATA_LEN;
 
-	//write to FIFO
-	select();
-	SPI.transfer(REG_FIFO | 0x80);
-	SPI.transfer(bufferSize + 3);
-	SPI.transfer(toAddress);
+  //write to FIFO
+  select();
+  SPI.transfer(REG_FIFO | 0x80);
+  SPI.transfer(bufferSize + 3);
+  SPI.transfer(toAddress);
   SPI.transfer(_address);
-  
+
   //control byte
   if (sendACK)
     SPI.transfer(0x80);
   else if (requestACK)
     SPI.transfer(0x40);
   else SPI.transfer(0x00);
-  
-	for (byte i = 0; i < bufferSize; i++)
-    SPI.transfer(((byte*)buffer)[i]);
-	unselect();
 
-	/* no need to wait for transmit mode to be ready since its handled by the radio */
-	setMode(RF69_MODE_TX);
+  for (byte i = 0; i < bufferSize; i++)
+    SPI.transfer(((byte*)buffer)[i]);
+  unselect();
+
+  /* no need to wait for transmit mode to be ready since its handled by the radio */
+  setMode(RF69_MODE_TX);
   unsigned long txStart = millis();
-	while (digitalRead(_interruptPin) == 0 && millis()-txStart < RF69_TX_LIMIT_MS); //wait for DIO0 to turn HIGH signalling transmission finish
+  while (digitalRead(_interruptPin) == 0 && millis()-txStart < RF69_TX_LIMIT_MS); //wait for DIO0 to turn HIGH signalling transmission finish
   //while (readReg(REG_IRQFLAGS2) & RF_IRQFLAGS2_PACKETSENT == 0x00); // Wait for ModeReady
   setMode(RF69_MODE_STANDBY);
 }
@@ -304,10 +304,10 @@ void RFM69::interruptHandler() {
     DATALEN = PAYLOADLEN - 3;
     SENDERID = SPI.transfer(0);
     byte CTLbyte = SPI.transfer(0);
-    
+
     ACK_RECEIVED = CTLbyte & 0x80; //extract ACK-requested flag
     ACK_REQUESTED = CTLbyte & 0x40; //extract ACK-received flag
-    
+
     for (byte i= 0; i < DATALEN; i++)
     {
       DATA[i] = SPI.transfer(0);
@@ -453,11 +453,11 @@ void RFM69::setCS(byte newSPISlaveSelect) {
 void RFM69::readAllRegs()
 {
   byte regVal;
-	
+
   for (byte regAddr = 1; regAddr <= 0x4F; regAddr++)
-	{
+  {
     select();
-    SPI.transfer(regAddr & 0x7f);	// send address + r/w bit
+    SPI.transfer(regAddr & 0x7f);  // send address + r/w bit
     regVal = SPI.transfer(0);
     unselect();
 
@@ -466,7 +466,7 @@ void RFM69::readAllRegs()
     Serial.print(regVal,HEX);
     Serial.print(" - ");
     Serial.println(regVal,BIN);
-	}
+  }
   unselect();
 }
 
@@ -476,7 +476,7 @@ byte RFM69::readTemperature(byte calFactor)  //returns centigrade
   writeReg(REG_TEMP1, RF_TEMP1_MEAS_START);
   while ((readReg(REG_TEMP1) & RF_TEMP1_MEAS_RUNNING));
   return ~readReg(REG_TEMP2) + COURSE_TEMP_COEF + calFactor; //'complement'corrects the slope, rising temp = rising val
-}												   	  // COURSE_TEMP_COEF puts reading in the ballpark, user can add additional correction
+} // COURSE_TEMP_COEF puts reading in the ballpark, user can add additional correction
 
 void RFM69::rcCalibration()
 {

--- a/RFM69.h
+++ b/RFM69.h
@@ -32,8 +32,8 @@
 #define RFM69_h
 #include <Arduino.h>            //assumes Arduino IDE v1.0 or greater
 
-#define RF69_MAX_DATA_LEN         61 // to take advantage of the built in AES/CRC we want to limit the frame size to the internal FIFO size (66 bytes - 3 bytes overhead)
-#define RF69_SPI_CS               SS // SS is the SPI slave select pin, for instance D10 on atmega328
+#define RF69_MAX_DATA_LEN       61 // to take advantage of the built in AES/CRC we want to limit the frame size to the internal FIFO size (66 bytes - 3 bytes overhead)
+#define RF69_SPI_CS             SS // SS is the SPI slave select pin, for instance D10 on atmega328
 
 // INT0 on AVRs should be connected to RFM69's DIO0 (ex on Atmega328 it's D2, on Atmega644/1284 it's D2)
 #if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__) || defined(__AVR_ATmega88) || defined(__AVR_ATmega8__) || defined(__AVR_ATmega88__)
@@ -48,29 +48,29 @@
 #endif
 
 
-#define CSMA_LIMIT          -90 // upper RX signal sensitivity threshold in dBm for carrier sense access
-#define RF69_MODE_SLEEP       0 // XTAL OFF
-#define	RF69_MODE_STANDBY     1 // XTAL ON
-#define RF69_MODE_SYNTH	      2 // PLL ON
-#define RF69_MODE_RX          3 // RX MODE
-#define RF69_MODE_TX		      4 // TX MODE
+#define CSMA_LIMIT              -90 // upper RX signal sensitivity threshold in dBm for carrier sense access
+#define RF69_MODE_SLEEP         0 // XTAL OFF
+#define  RF69_MODE_STANDBY      1 // XTAL ON
+#define RF69_MODE_SYNTH         2 // PLL ON
+#define RF69_MODE_RX            3 // RX MODE
+#define RF69_MODE_TX            4 // TX MODE
 
 //available frequency bands
-#define RF69_315MHZ     31  // non trivial values to avoid misconfiguration
-#define RF69_433MHZ     43
-#define RF69_868MHZ     86
-#define RF69_915MHZ     91
+#define RF69_315MHZ            31 // non trivial values to avoid misconfiguration
+#define RF69_433MHZ            43
+#define RF69_868MHZ            86
+#define RF69_915MHZ            91
 
 #define null                  0
 #define COURSE_TEMP_COEF    -90 // puts the temperature reading in the ballpark, user can fine tune the returned value
 #define RF69_BROADCAST_ADDR 255
 #define RF69_CSMA_LIMIT_MS 1000
-#define RF69_TX_LIMIT_MS 1000
-#define RF69_FSTEP 61.03515625 // == FXOSC/2^19 = 32mhz/2^19 (p13 in DS)
+#define RF69_TX_LIMIT_MS   1000
+#define RF69_FSTEP  61.03515625 // == FXOSC/2^19 = 32mhz/2^19 (p13 in DS)
 
 class RFM69 {
   public:
-    static volatile byte DATA[RF69_MAX_DATA_LEN];          // recv/xmit buf, including hdr & crc bytes
+    static volatile byte DATA[RF69_MAX_DATA_LEN]; // recv/xmit buf, including hdr & crc bytes
     static volatile byte DATALEN;
     static volatile byte SENDERID;
     static volatile byte TARGETID; //should match _address
@@ -79,7 +79,7 @@ class RFM69 {
     static volatile byte ACK_RECEIVED; /// Should be polled immediately after sending a packet with ACK request
     static volatile int RSSI; //most accurate RSSI during reception (closest to the reception)
     static volatile byte _mode; //should be protected?
-    
+
     RFM69(byte slaveSelectPin=RF69_SPI_CS, byte interruptPin=RF69_IRQ_PIN, bool isRFM69HW=false, byte interruptNum=RF69_IRQ_NUM) {
       _slaveSelectPin = slaveSelectPin;
       _interruptPin = interruptPin;

--- a/RFM69.h
+++ b/RFM69.h
@@ -30,7 +30,7 @@
 // **********************************************************************************
 #ifndef RFM69_h
 #define RFM69_h
-#include <Arduino.h>            //assumes Arduino IDE v1.0 or greater
+#include <Arduino.h>            // assumes Arduino IDE v1.0 or greater
 
 #define RF69_MAX_DATA_LEN       61 // to take advantage of the built in AES/CRC we want to limit the frame size to the internal FIFO size (66 bytes - 3 bytes overhead)
 #define RF69_SPI_CS             SS // SS is the SPI slave select pin, for instance D10 on atmega328
@@ -55,7 +55,7 @@
 #define RF69_MODE_RX            3 // RX MODE
 #define RF69_MODE_TX            4 // TX MODE
 
-//available frequency bands
+// available frequency bands
 #define RF69_315MHZ            31 // non trivial values to avoid misconfiguration
 #define RF69_433MHZ            43
 #define RF69_868MHZ            86
@@ -73,12 +73,12 @@ class RFM69 {
     static volatile byte DATA[RF69_MAX_DATA_LEN]; // recv/xmit buf, including hdr & crc bytes
     static volatile byte DATALEN;
     static volatile byte SENDERID;
-    static volatile byte TARGETID; //should match _address
+    static volatile byte TARGETID; // should match _address
     static volatile byte PAYLOADLEN;
     static volatile byte ACK_REQUESTED;
-    static volatile byte ACK_RECEIVED; /// Should be polled immediately after sending a packet with ACK request
-    static volatile int RSSI; //most accurate RSSI during reception (closest to the reception)
-    static volatile byte _mode; //should be protected?
+    static volatile byte ACK_RECEIVED; // Should be polled immediately after sending a packet with ACK request
+    static volatile int RSSI; // most accurate RSSI during reception (closest to the reception)
+    static volatile byte _mode; // should be protected?
 
     RFM69(byte slaveSelectPin=RF69_SPI_CS, byte interruptPin=RF69_IRQ_PIN, bool isRFM69HW=false, byte interruptNum=RF69_IRQ_NUM) {
       _slaveSelectPin = slaveSelectPin;
@@ -95,7 +95,7 @@ class RFM69 {
     void setNetwork(byte networkID);
     bool canSend();
     void send(byte toAddress, const void* buffer, byte bufferSize, bool requestACK=false);
-    bool sendWithRetry(byte toAddress, const void* buffer, byte bufferSize, byte retries=2, byte retryWaitTime=40); //40ms roundtrip req for  61byte packets
+    bool sendWithRetry(byte toAddress, const void* buffer, byte bufferSize, byte retries=2, byte retryWaitTime=40); // 40ms roundtrip req for  61byte packets
     bool receiveDone();
     bool ACKReceived(byte fromNodeID);
     bool ACKRequested();
@@ -106,11 +106,11 @@ class RFM69 {
     void setCS(byte newSPISlaveSelect);
     int readRSSI(bool forceTrigger=false);
     void promiscuous(bool onOff=true);
-    void setHighPower(bool onOFF=true); //have to call it after initialize for RFM69HW
-    void setPowerLevel(byte level); //reduce/increase transmit power level
+    void setHighPower(bool onOFF=true); // have to call it after initialize for RFM69HW
+    void setPowerLevel(byte level); // reduce/increase transmit power level
     void sleep();
-    byte readTemperature(byte calFactor=0); //get CMOS temperature (8bit)
-    void rcCalibration(); //calibrate the internal RC oscillator for use in wide temperature variations - see datasheet section [4.3.5. RC Timer Accuracy]
+    byte readTemperature(byte calFactor=0); // get CMOS temperature (8bit)
+    void rcCalibration(); // calibrate the internal RC oscillator for use in wide temperature variations - see datasheet section [4.3.5. RC Timer Accuracy]
 
     // allow hacking registers by making these public
     byte readReg(byte addr);

--- a/RFM69registers.h
+++ b/RFM69registers.h
@@ -111,8 +111,8 @@
 #define REG_AESKEY16      0x4D
 #define REG_TEMP1         0x4E
 #define REG_TEMP2         0x4F
-#define REG_TESTPA1       0x5A //only present on RFM69HW/SX1231H
-#define REG_TESTPA2       0x5C //only present on RFM69HW/SX1231H
+#define REG_TESTPA1       0x5A // only present on RFM69HW/SX1231H
+#define REG_TESTPA2       0x5C // only present on RFM69HW/SX1231H
 #define REG_TESTDAGC      0x6F
 
 //******************************************************
@@ -192,7 +192,7 @@
 #define RF_BITRATELSB_300000          0x6B
 #define RF_BITRATEMSB_32768           0x03
 #define RF_BITRATELSB_32768           0xD1
-//custom bit rates
+// custom bit rates
 #define RF_BITRATEMSB_55555           0x02
 #define RF_BITRATELSB_55555           0x40
 #define RF_BITRATEMSB_200KBPS         0x00
@@ -1066,4 +1066,3 @@
 #define RF_DAGC_NORMAL              0x00  // Reset value
 #define RF_DAGC_IMPROVED_LOWBETA1   0x20  //
 #define RF_DAGC_IMPROVED_LOWBETA0   0x30  // Recommended default
-

--- a/RFM69registers.h
+++ b/RFM69registers.h
@@ -31,86 +31,86 @@
 // **********************************************************************************
 // RFM69/SX1231 Internal registers addresses
 //**************************************************
-#define REG_FIFO			    0x00
-#define REG_OPMODE			  0x01
-#define REG_DATAMODUL	  	0x02
-#define REG_BITRATEMSB		0x03
-#define REG_BITRATELSB		0x04
-#define REG_FDEVMSB			  0x05
-#define REG_FDEVLSB		  	0x06
-#define REG_FRFMSB	  		0x07
-#define REG_FRFMID			  0x08
-#define REG_FRFLSB		  	0x09
-#define REG_OSC1		  	  0x0A
-#define REG_AFCCTRL 		  0x0B
-#define REG_LOWBAT			  0x0C
-#define REG_LISTEN1			  0x0D
-#define REG_LISTEN2			  0x0E
-#define REG_LISTEN3			  0x0F
-#define REG_VERSION			  0x10
-#define REG_PALEVEL			  0x11
-#define REG_PARAMP			  0x12
-#define REG_OCP				    0x13
-#define REG_AGCREF			  0x14
-#define REG_AGCTHRESH1		0x15
-#define REG_AGCTHRESH2		0x16
-#define REG_AGCTHRESH3		0x17
-#define REG_LNA			  	  0x18
-#define REG_RXBW		    	0x19
-#define REG_AFCBW		    	0x1A
-#define REG_OOKPEAK	  		0x1B
-#define REG_OOKAVG  			0x1C
-#define REG_OOKFIX	  		0x1D
-#define REG_AFCFEI		  	0x1E
-#define REG_AFCMSB			  0x1F
-#define REG_AFCLSB			  0x20
-#define REG_FEIMSB			  0x21
-#define REG_FEILSB			  0x22
-#define REG_RSSICONFIG		0x23
-#define REG_RSSIVALUE		  0x24
-#define REG_DIOMAPPING1		0x25
-#define REG_DIOMAPPING2		0x26
-#define REG_IRQFLAGS1		  0x27
-#define REG_IRQFLAGS2		  0x28
-#define REG_RSSITHRESH		0x29
-#define REG_RXTIMEOUT1		0x2A
-#define REG_RXTIMEOUT2		0x2B
-#define REG_PREAMBLEMSB		0x2C
-#define REG_PREAMBLELSB		0x2D
-#define REG_SYNCCONFIG		0x2E
-#define REG_SYNCVALUE1		0x2F
-#define REG_SYNCVALUE2		0x30
-#define REG_SYNCVALUE3		0x31
-#define REG_SYNCVALUE4		0x32
-#define REG_SYNCVALUE5		0x33
-#define REG_SYNCVALUE6		0x34
-#define REG_SYNCVALUE7		0x35
-#define REG_SYNCVALUE8		0x36
-#define REG_PACKETCONFIG1	0x37
-#define REG_PAYLOADLENGTH	0x38
-#define REG_NODEADRS		  0x39
-#define REG_BROADCASTADRS	0x3A
-#define REG_AUTOMODES		  0x3B
-#define REG_FIFOTHRESH		0x3C
-#define REG_PACKETCONFIG2	0x3D
-#define REG_AESKEY1			  0x3E
-#define REG_AESKEY2 			0x3F
-#define REG_AESKEY3	  		0x40
-#define REG_AESKEY4		  	0x41
-#define REG_AESKEY5			  0x42
-#define REG_AESKEY6 			0x43
-#define REG_AESKEY7	  		0x44
-#define REG_AESKEY8		  	0x45
-#define REG_AESKEY9			  0x46
-#define REG_AESKEY10  		0x47
-#define REG_AESKEY11	  	0x48
-#define REG_AESKEY12		  0x49
-#define REG_AESKEY13  		0x4A
-#define REG_AESKEY14	  	0x4B
-#define REG_AESKEY15		  0x4C
-#define REG_AESKEY16		  0x4D
-#define REG_TEMP1			    0x4E
-#define REG_TEMP2			    0x4F
+#define REG_FIFO          0x00
+#define REG_OPMODE        0x01
+#define REG_DATAMODUL     0x02
+#define REG_BITRATEMSB    0x03
+#define REG_BITRATELSB    0x04
+#define REG_FDEVMSB       0x05
+#define REG_FDEVLSB       0x06
+#define REG_FRFMSB        0x07
+#define REG_FRFMID        0x08
+#define REG_FRFLSB        0x09
+#define REG_OSC1          0x0A
+#define REG_AFCCTRL       0x0B
+#define REG_LOWBAT        0x0C
+#define REG_LISTEN1       0x0D
+#define REG_LISTEN2       0x0E
+#define REG_LISTEN3       0x0F
+#define REG_VERSION       0x10
+#define REG_PALEVEL       0x11
+#define REG_PARAMP        0x12
+#define REG_OCP           0x13
+#define REG_AGCREF        0x14
+#define REG_AGCTHRESH1    0x15
+#define REG_AGCTHRESH2    0x16
+#define REG_AGCTHRESH3    0x17
+#define REG_LNA           0x18
+#define REG_RXBW          0x19
+#define REG_AFCBW         0x1A
+#define REG_OOKPEAK       0x1B
+#define REG_OOKAVG        0x1C
+#define REG_OOKFIX        0x1D
+#define REG_AFCFEI        0x1E
+#define REG_AFCMSB        0x1F
+#define REG_AFCLSB        0x20
+#define REG_FEIMSB        0x21
+#define REG_FEILSB        0x22
+#define REG_RSSICONFIG    0x23
+#define REG_RSSIVALUE     0x24
+#define REG_DIOMAPPING1   0x25
+#define REG_DIOMAPPING2   0x26
+#define REG_IRQFLAGS1     0x27
+#define REG_IRQFLAGS2     0x28
+#define REG_RSSITHRESH    0x29
+#define REG_RXTIMEOUT1    0x2A
+#define REG_RXTIMEOUT2    0x2B
+#define REG_PREAMBLEMSB   0x2C
+#define REG_PREAMBLELSB   0x2D
+#define REG_SYNCCONFIG    0x2E
+#define REG_SYNCVALUE1    0x2F
+#define REG_SYNCVALUE2    0x30
+#define REG_SYNCVALUE3    0x31
+#define REG_SYNCVALUE4    0x32
+#define REG_SYNCVALUE5    0x33
+#define REG_SYNCVALUE6    0x34
+#define REG_SYNCVALUE7    0x35
+#define REG_SYNCVALUE8    0x36
+#define REG_PACKETCONFIG1 0x37
+#define REG_PAYLOADLENGTH 0x38
+#define REG_NODEADRS      0x39
+#define REG_BROADCASTADRS 0x3A
+#define REG_AUTOMODES     0x3B
+#define REG_FIFOTHRESH    0x3C
+#define REG_PACKETCONFIG2 0x3D
+#define REG_AESKEY1       0x3E
+#define REG_AESKEY2       0x3F
+#define REG_AESKEY3       0x40
+#define REG_AESKEY4       0x41
+#define REG_AESKEY5       0x42
+#define REG_AESKEY6       0x43
+#define REG_AESKEY7       0x44
+#define REG_AESKEY8       0x45
+#define REG_AESKEY9       0x46
+#define REG_AESKEY10      0x47
+#define REG_AESKEY11      0x48
+#define REG_AESKEY12      0x49
+#define REG_AESKEY13      0x4A
+#define REG_AESKEY14      0x4B
+#define REG_AESKEY15      0x4C
+#define REG_AESKEY16      0x4D
+#define REG_TEMP1         0x4E
+#define REG_TEMP2         0x4F
 #define REG_TESTPA1       0x5A //only present on RFM69HW/SX1231H
 #define REG_TESTPA2       0x5C //only present on RFM69HW/SX1231H
 #define REG_TESTDAGC      0x6F
@@ -119,948 +119,948 @@
 // RF69/SX1231 bit control definition
 //******************************************************
 // RegOpMode
-#define RF_OPMODE_SEQUENCER_OFF				0x80
-#define RF_OPMODE_SEQUENCER_ON				0x00  // Default
+#define RF_OPMODE_SEQUENCER_OFF       0x80
+#define RF_OPMODE_SEQUENCER_ON        0x00  // Default
 
-#define RF_OPMODE_LISTEN_ON						0x40
-#define RF_OPMODE_LISTEN_OFF					0x00  // Default
+#define RF_OPMODE_LISTEN_ON           0x40
+#define RF_OPMODE_LISTEN_OFF          0x00  // Default
 
-#define RF_OPMODE_LISTENABORT					0x20
+#define RF_OPMODE_LISTENABORT         0x20
 
-#define RF_OPMODE_SLEEP							  0x00
-#define RF_OPMODE_STANDBY						  0x04  // Default
-#define RF_OPMODE_SYNTHESIZER					0x08
-#define RF_OPMODE_TRANSMITTER					0x0C
-#define RF_OPMODE_RECEIVER						0x10
+#define RF_OPMODE_SLEEP               0x00
+#define RF_OPMODE_STANDBY             0x04  // Default
+#define RF_OPMODE_SYNTHESIZER         0x08
+#define RF_OPMODE_TRANSMITTER         0x0C
+#define RF_OPMODE_RECEIVER            0x10
 
 // RegDataModul
-#define RF_DATAMODUL_DATAMODE_PACKET			      0x00  // Default
-#define RF_DATAMODUL_DATAMODE_CONTINUOUS		    0x40
-#define RF_DATAMODUL_DATAMODE_CONTINUOUSNOBSYNC	0x60
+#define RF_DATAMODUL_DATAMODE_PACKET            0x00  // Default
+#define RF_DATAMODUL_DATAMODE_CONTINUOUS        0x40
+#define RF_DATAMODUL_DATAMODE_CONTINUOUSNOBSYNC 0x60
 
-#define RF_DATAMODUL_MODULATIONTYPE_FSK			    0x00  // Default
-#define RF_DATAMODUL_MODULATIONTYPE_OOK			    0x08
+#define RF_DATAMODUL_MODULATIONTYPE_FSK         0x00  // Default
+#define RF_DATAMODUL_MODULATIONTYPE_OOK         0x08
 
-#define RF_DATAMODUL_MODULATIONSHAPING_00		    0x00  // Default
-#define RF_DATAMODUL_MODULATIONSHAPING_01		    0x01
-#define RF_DATAMODUL_MODULATIONSHAPING_10		    0x02
-#define RF_DATAMODUL_MODULATIONSHAPING_11		    0x03
+#define RF_DATAMODUL_MODULATIONSHAPING_00       0x00  // Default
+#define RF_DATAMODUL_MODULATIONSHAPING_01       0x01
+#define RF_DATAMODUL_MODULATIONSHAPING_10       0x02
+#define RF_DATAMODUL_MODULATIONSHAPING_11       0x03
 
 // RegBitRate (bits/sec) example bit rates
-#define RF_BITRATEMSB_1200						0x68
-#define RF_BITRATELSB_1200						0x2B
-#define RF_BITRATEMSB_2400						0x34
-#define RF_BITRATELSB_2400						0x15
-#define RF_BITRATEMSB_4800						0x1A  // Default
-#define RF_BITRATELSB_4800						0x0B  // Default
-#define RF_BITRATEMSB_9600						0x0D
-#define RF_BITRATELSB_9600						0x05
-#define RF_BITRATEMSB_19200						0x06
-#define RF_BITRATELSB_19200						0x83
-#define RF_BITRATEMSB_38400						0x03
-#define RF_BITRATELSB_38400						0x41
+#define RF_BITRATEMSB_1200            0x68
+#define RF_BITRATELSB_1200            0x2B
+#define RF_BITRATEMSB_2400            0x34
+#define RF_BITRATELSB_2400            0x15
+#define RF_BITRATEMSB_4800            0x1A  // Default
+#define RF_BITRATELSB_4800            0x0B  // Default
+#define RF_BITRATEMSB_9600            0x0D
+#define RF_BITRATELSB_9600            0x05
+#define RF_BITRATEMSB_19200           0x06
+#define RF_BITRATELSB_19200           0x83
+#define RF_BITRATEMSB_38400           0x03
+#define RF_BITRATELSB_38400           0x41
 
-#define RF_BITRATEMSB_38323						0x03
-#define RF_BITRATELSB_38323						0x43
+#define RF_BITRATEMSB_38323           0x03
+#define RF_BITRATELSB_38323           0x43
 
-#define RF_BITRATEMSB_34482						0x03
-#define RF_BITRATELSB_34482						0xA0
+#define RF_BITRATEMSB_34482           0x03
+#define RF_BITRATELSB_34482           0xA0
 
-#define RF_BITRATEMSB_76800						0x01
-#define RF_BITRATELSB_76800						0xA1
-#define RF_BITRATEMSB_153600					0x00
-#define RF_BITRATELSB_153600					0xD0
-#define RF_BITRATEMSB_57600						0x02
-#define RF_BITRATELSB_57600						0x2C
-#define RF_BITRATEMSB_115200					0x01
-#define RF_BITRATELSB_115200					0x16
-#define RF_BITRATEMSB_12500						0x0A
-#define RF_BITRATELSB_12500						0x00
-#define RF_BITRATEMSB_25000						0x05
-#define RF_BITRATELSB_25000						0x00
-#define RF_BITRATEMSB_50000						0x02
-#define RF_BITRATELSB_50000						0x80
-#define RF_BITRATEMSB_100000					0x01
-#define RF_BITRATELSB_100000					0x40
-#define RF_BITRATEMSB_150000					0x00
-#define RF_BITRATELSB_150000					0xD5
-#define RF_BITRATEMSB_200000					0x00
-#define RF_BITRATELSB_200000					0xA0
-#define RF_BITRATEMSB_250000					0x00
-#define RF_BITRATELSB_250000					0x80
-#define RF_BITRATEMSB_300000					0x00
-#define RF_BITRATELSB_300000					0x6B
-#define RF_BITRATEMSB_32768						0x03
-#define RF_BITRATELSB_32768						0xD1
+#define RF_BITRATEMSB_76800           0x01
+#define RF_BITRATELSB_76800           0xA1
+#define RF_BITRATEMSB_153600          0x00
+#define RF_BITRATELSB_153600          0xD0
+#define RF_BITRATEMSB_57600           0x02
+#define RF_BITRATELSB_57600           0x2C
+#define RF_BITRATEMSB_115200          0x01
+#define RF_BITRATELSB_115200          0x16
+#define RF_BITRATEMSB_12500           0x0A
+#define RF_BITRATELSB_12500           0x00
+#define RF_BITRATEMSB_25000           0x05
+#define RF_BITRATELSB_25000           0x00
+#define RF_BITRATEMSB_50000           0x02
+#define RF_BITRATELSB_50000           0x80
+#define RF_BITRATEMSB_100000          0x01
+#define RF_BITRATELSB_100000          0x40
+#define RF_BITRATEMSB_150000          0x00
+#define RF_BITRATELSB_150000          0xD5
+#define RF_BITRATEMSB_200000          0x00
+#define RF_BITRATELSB_200000          0xA0
+#define RF_BITRATEMSB_250000          0x00
+#define RF_BITRATELSB_250000          0x80
+#define RF_BITRATEMSB_300000          0x00
+#define RF_BITRATELSB_300000          0x6B
+#define RF_BITRATEMSB_32768           0x03
+#define RF_BITRATELSB_32768           0xD1
 //custom bit rates
-#define RF_BITRATEMSB_55555     0x02
-#define RF_BITRATELSB_55555     0x40
-#define RF_BITRATEMSB_200KBPS      0x00
-#define RF_BITRATELSB_200KBPS      0xa0
+#define RF_BITRATEMSB_55555           0x02
+#define RF_BITRATELSB_55555           0x40
+#define RF_BITRATEMSB_200KBPS         0x00
+#define RF_BITRATELSB_200KBPS         0xa0
 
 // RegFdev - frequency deviation (Hz)
-#define RF_FDEVMSB_2000							0x00
-#define RF_FDEVLSB_2000							0x21
-#define RF_FDEVMSB_5000							0x00  // Default
-#define RF_FDEVLSB_5000							0x52  // Default
-#define RF_FDEVMSB_7500							0x00
-#define RF_FDEVLSB_7500							0x7B
-#define RF_FDEVMSB_10000						0x00
-#define RF_FDEVLSB_10000						0xA4
-#define RF_FDEVMSB_15000						0x00
-#define RF_FDEVLSB_15000						0xF6
-#define RF_FDEVMSB_20000						0x01
-#define RF_FDEVLSB_20000						0x48
-#define RF_FDEVMSB_25000						0x01
-#define RF_FDEVLSB_25000						0x9A
-#define RF_FDEVMSB_30000						0x01
-#define RF_FDEVLSB_30000						0xEC
-#define RF_FDEVMSB_35000						0x02
-#define RF_FDEVLSB_35000						0x3D
-#define RF_FDEVMSB_40000						0x02
-#define RF_FDEVLSB_40000						0x8F
-#define RF_FDEVMSB_45000						0x02
-#define RF_FDEVLSB_45000						0xE1
-#define RF_FDEVMSB_50000						0x03
-#define RF_FDEVLSB_50000						0x33
-#define RF_FDEVMSB_55000						0x03
-#define RF_FDEVLSB_55000						0x85
-#define RF_FDEVMSB_60000						0x03
-#define RF_FDEVLSB_60000						0xD7
-#define RF_FDEVMSB_65000						0x04
-#define RF_FDEVLSB_65000						0x29
-#define RF_FDEVMSB_70000						0x04
-#define RF_FDEVLSB_70000						0x7B
-#define RF_FDEVMSB_75000						0x04
-#define RF_FDEVLSB_75000						0xCD
-#define RF_FDEVMSB_80000						0x05
-#define RF_FDEVLSB_80000						0x1F
-#define RF_FDEVMSB_85000						0x05
-#define RF_FDEVLSB_85000						0x71
-#define RF_FDEVMSB_90000						0x05
-#define RF_FDEVLSB_90000						0xC3
-#define RF_FDEVMSB_95000						0x06
-#define RF_FDEVLSB_95000						0x14
-#define RF_FDEVMSB_100000						0x06
-#define RF_FDEVLSB_100000						0x66
-#define RF_FDEVMSB_110000						0x07
-#define RF_FDEVLSB_110000						0x0A
-#define RF_FDEVMSB_120000						0x07
-#define RF_FDEVLSB_120000						0xAE
-#define RF_FDEVMSB_130000						0x08
-#define RF_FDEVLSB_130000						0x52
-#define RF_FDEVMSB_140000						0x08
-#define RF_FDEVLSB_140000						0xF6
-#define RF_FDEVMSB_150000						0x09
-#define RF_FDEVLSB_150000						0x9A
-#define RF_FDEVMSB_160000						0x0A
-#define RF_FDEVLSB_160000						0x3D
-#define RF_FDEVMSB_170000						0x0A
-#define RF_FDEVLSB_170000						0xE1
-#define RF_FDEVMSB_180000						0x0B
-#define RF_FDEVLSB_180000						0x85
-#define RF_FDEVMSB_190000						0x0C
-#define RF_FDEVLSB_190000						0x29
-#define RF_FDEVMSB_200000						0x0C
-#define RF_FDEVLSB_200000						0xCD
-#define RF_FDEVMSB_210000						0x0D
-#define RF_FDEVLSB_210000						0x71
-#define RF_FDEVMSB_220000						0x0E
-#define RF_FDEVLSB_220000						0x14
-#define RF_FDEVMSB_230000						0x0E
-#define RF_FDEVLSB_230000						0xB8
-#define RF_FDEVMSB_240000						0x0F
-#define RF_FDEVLSB_240000						0x5C
-#define RF_FDEVMSB_250000						0x10
-#define RF_FDEVLSB_250000						0x00
-#define RF_FDEVMSB_260000						0x10
-#define RF_FDEVLSB_260000						0xA4
-#define RF_FDEVMSB_270000						0x11
-#define RF_FDEVLSB_270000						0x48
-#define RF_FDEVMSB_280000						0x11
-#define RF_FDEVLSB_280000						0xEC
-#define RF_FDEVMSB_290000						0x12
-#define RF_FDEVLSB_290000						0x8F
-#define RF_FDEVMSB_300000						0x13
-#define RF_FDEVLSB_300000						0x33
+#define RF_FDEVMSB_2000             0x00
+#define RF_FDEVLSB_2000             0x21
+#define RF_FDEVMSB_5000             0x00  // Default
+#define RF_FDEVLSB_5000             0x52  // Default
+#define RF_FDEVMSB_7500             0x00
+#define RF_FDEVLSB_7500             0x7B
+#define RF_FDEVMSB_10000            0x00
+#define RF_FDEVLSB_10000            0xA4
+#define RF_FDEVMSB_15000            0x00
+#define RF_FDEVLSB_15000            0xF6
+#define RF_FDEVMSB_20000            0x01
+#define RF_FDEVLSB_20000            0x48
+#define RF_FDEVMSB_25000            0x01
+#define RF_FDEVLSB_25000            0x9A
+#define RF_FDEVMSB_30000            0x01
+#define RF_FDEVLSB_30000            0xEC
+#define RF_FDEVMSB_35000            0x02
+#define RF_FDEVLSB_35000            0x3D
+#define RF_FDEVMSB_40000            0x02
+#define RF_FDEVLSB_40000            0x8F
+#define RF_FDEVMSB_45000            0x02
+#define RF_FDEVLSB_45000            0xE1
+#define RF_FDEVMSB_50000            0x03
+#define RF_FDEVLSB_50000            0x33
+#define RF_FDEVMSB_55000            0x03
+#define RF_FDEVLSB_55000            0x85
+#define RF_FDEVMSB_60000            0x03
+#define RF_FDEVLSB_60000            0xD7
+#define RF_FDEVMSB_65000            0x04
+#define RF_FDEVLSB_65000            0x29
+#define RF_FDEVMSB_70000            0x04
+#define RF_FDEVLSB_70000            0x7B
+#define RF_FDEVMSB_75000            0x04
+#define RF_FDEVLSB_75000            0xCD
+#define RF_FDEVMSB_80000            0x05
+#define RF_FDEVLSB_80000            0x1F
+#define RF_FDEVMSB_85000            0x05
+#define RF_FDEVLSB_85000            0x71
+#define RF_FDEVMSB_90000            0x05
+#define RF_FDEVLSB_90000            0xC3
+#define RF_FDEVMSB_95000            0x06
+#define RF_FDEVLSB_95000            0x14
+#define RF_FDEVMSB_100000           0x06
+#define RF_FDEVLSB_100000           0x66
+#define RF_FDEVMSB_110000           0x07
+#define RF_FDEVLSB_110000           0x0A
+#define RF_FDEVMSB_120000           0x07
+#define RF_FDEVLSB_120000           0xAE
+#define RF_FDEVMSB_130000           0x08
+#define RF_FDEVLSB_130000           0x52
+#define RF_FDEVMSB_140000           0x08
+#define RF_FDEVLSB_140000           0xF6
+#define RF_FDEVMSB_150000           0x09
+#define RF_FDEVLSB_150000           0x9A
+#define RF_FDEVMSB_160000           0x0A
+#define RF_FDEVLSB_160000           0x3D
+#define RF_FDEVMSB_170000           0x0A
+#define RF_FDEVLSB_170000           0xE1
+#define RF_FDEVMSB_180000           0x0B
+#define RF_FDEVLSB_180000           0x85
+#define RF_FDEVMSB_190000           0x0C
+#define RF_FDEVLSB_190000           0x29
+#define RF_FDEVMSB_200000           0x0C
+#define RF_FDEVLSB_200000           0xCD
+#define RF_FDEVMSB_210000           0x0D
+#define RF_FDEVLSB_210000           0x71
+#define RF_FDEVMSB_220000           0x0E
+#define RF_FDEVLSB_220000           0x14
+#define RF_FDEVMSB_230000           0x0E
+#define RF_FDEVLSB_230000           0xB8
+#define RF_FDEVMSB_240000           0x0F
+#define RF_FDEVLSB_240000           0x5C
+#define RF_FDEVMSB_250000           0x10
+#define RF_FDEVLSB_250000           0x00
+#define RF_FDEVMSB_260000           0x10
+#define RF_FDEVLSB_260000           0xA4
+#define RF_FDEVMSB_270000           0x11
+#define RF_FDEVLSB_270000           0x48
+#define RF_FDEVMSB_280000           0x11
+#define RF_FDEVLSB_280000           0xEC
+#define RF_FDEVMSB_290000           0x12
+#define RF_FDEVLSB_290000           0x8F
+#define RF_FDEVMSB_300000           0x13
+#define RF_FDEVLSB_300000           0x33
 
 // RegFrf (MHz) - carrier frequency
 // 315Mhz band
-#define RF_FRFMSB_314							0x4E
-#define RF_FRFMID_314							0x80
-#define RF_FRFLSB_314							0x00
-#define RF_FRFMSB_315							0x4E
-#define RF_FRFMID_315							0xC0
-#define RF_FRFLSB_315							0x00
-#define RF_FRFMSB_316							0x4F
-#define RF_FRFMID_316							0x00
-#define RF_FRFLSB_316							0x00
+#define RF_FRFMSB_314             0x4E
+#define RF_FRFMID_314             0x80
+#define RF_FRFLSB_314             0x00
+#define RF_FRFMSB_315             0x4E
+#define RF_FRFMID_315             0xC0
+#define RF_FRFLSB_315             0x00
+#define RF_FRFMSB_316             0x4F
+#define RF_FRFMID_316             0x00
+#define RF_FRFLSB_316             0x00
 // 433mhz band
-#define RF_FRFMSB_433							0x6C
-#define RF_FRFMID_433							0x40
-#define RF_FRFLSB_433							0x00
-#define RF_FRFMSB_434							0x6C
-#define RF_FRFMID_434							0x80
-#define RF_FRFLSB_434							0x00
-#define RF_FRFMSB_435							0x6C
-#define RF_FRFMID_435							0xC0
-#define RF_FRFLSB_435							0x00
+#define RF_FRFMSB_433             0x6C
+#define RF_FRFMID_433             0x40
+#define RF_FRFLSB_433             0x00
+#define RF_FRFMSB_434             0x6C
+#define RF_FRFMID_434             0x80
+#define RF_FRFLSB_434             0x00
+#define RF_FRFMSB_435             0x6C
+#define RF_FRFMID_435             0xC0
+#define RF_FRFLSB_435             0x00
 // 868Mhz band
-#define RF_FRFMSB_863							0xD7
-#define RF_FRFMID_863							0xC0
-#define RF_FRFLSB_863							0x00
-#define RF_FRFMSB_864							0xD8
-#define RF_FRFMID_864							0x00
-#define RF_FRFLSB_864							0x00
-#define RF_FRFMSB_865							0xD8
-#define RF_FRFMID_865							0x40
-#define RF_FRFLSB_865							0x00
-#define RF_FRFMSB_866							0xD8
-#define RF_FRFMID_866							0x80
-#define RF_FRFLSB_866							0x00
-#define RF_FRFMSB_867							0xD8
-#define RF_FRFMID_867							0xC0
-#define RF_FRFLSB_867							0x00
-#define RF_FRFMSB_868							0xD9
-#define RF_FRFMID_868							0x00
-#define RF_FRFLSB_868							0x00
-#define RF_FRFMSB_869							0xD9
-#define RF_FRFMID_869							0x40
-#define RF_FRFLSB_869							0x00
-#define RF_FRFMSB_870							0xD9
-#define RF_FRFMID_870							0x80
-#define RF_FRFLSB_870							0x00
+#define RF_FRFMSB_863             0xD7
+#define RF_FRFMID_863             0xC0
+#define RF_FRFLSB_863             0x00
+#define RF_FRFMSB_864             0xD8
+#define RF_FRFMID_864             0x00
+#define RF_FRFLSB_864             0x00
+#define RF_FRFMSB_865             0xD8
+#define RF_FRFMID_865             0x40
+#define RF_FRFLSB_865             0x00
+#define RF_FRFMSB_866             0xD8
+#define RF_FRFMID_866             0x80
+#define RF_FRFLSB_866             0x00
+#define RF_FRFMSB_867             0xD8
+#define RF_FRFMID_867             0xC0
+#define RF_FRFLSB_867             0x00
+#define RF_FRFMSB_868             0xD9
+#define RF_FRFMID_868             0x00
+#define RF_FRFLSB_868             0x00
+#define RF_FRFMSB_869             0xD9
+#define RF_FRFMID_869             0x40
+#define RF_FRFLSB_869             0x00
+#define RF_FRFMSB_870             0xD9
+#define RF_FRFMID_870             0x80
+#define RF_FRFLSB_870             0x00
 // 915Mhz band
-#define RF_FRFMSB_902							0xE1
-#define RF_FRFMID_902							0x80
-#define RF_FRFLSB_902							0x00
-#define RF_FRFMSB_903							0xE1
-#define RF_FRFMID_903							0xC0
-#define RF_FRFLSB_903							0x00
-#define RF_FRFMSB_904							0xE2
-#define RF_FRFMID_904							0x00
-#define RF_FRFLSB_904							0x00
-#define RF_FRFMSB_905							0xE2
-#define RF_FRFMID_905							0x40
-#define RF_FRFLSB_905							0x00
-#define RF_FRFMSB_906							0xE2
-#define RF_FRFMID_906							0x80
-#define RF_FRFLSB_906							0x00
-#define RF_FRFMSB_907							0xE2
-#define RF_FRFMID_907							0xC0
-#define RF_FRFLSB_907							0x00
-#define RF_FRFMSB_908							0xE3
-#define RF_FRFMID_908							0x00
-#define RF_FRFLSB_908							0x00
-#define RF_FRFMSB_909							0xE3
-#define RF_FRFMID_909							0x40
-#define RF_FRFLSB_909							0x00
-#define RF_FRFMSB_910							0xE3
-#define RF_FRFMID_910							0x80
-#define RF_FRFLSB_910							0x00
-#define RF_FRFMSB_911							0xE3
-#define RF_FRFMID_911							0xC0
-#define RF_FRFLSB_911							0x00
-#define RF_FRFMSB_912							0xE4
-#define RF_FRFMID_912							0x00
-#define RF_FRFLSB_912							0x00
-#define RF_FRFMSB_913							0xE4
-#define RF_FRFMID_913							0x40
-#define RF_FRFLSB_913							0x00
-#define RF_FRFMSB_914							0xE4
-#define RF_FRFMID_914							0x80
-#define RF_FRFLSB_914							0x00
-#define RF_FRFMSB_915							0xE4  // Default
-#define RF_FRFMID_915							0xC0  // Default
-#define RF_FRFLSB_915							0x00  // Default
-#define RF_FRFMSB_916							0xE5
-#define RF_FRFMID_916							0x00
-#define RF_FRFLSB_916							0x00
-#define RF_FRFMSB_917							0xE5
-#define RF_FRFMID_917							0x40
-#define RF_FRFLSB_917							0x00
-#define RF_FRFMSB_918							0xE5
-#define RF_FRFMID_918							0x80
-#define RF_FRFLSB_918							0x00
-#define RF_FRFMSB_919							0xE5
-#define RF_FRFMID_919							0xC0
-#define RF_FRFLSB_919							0x00
-#define RF_FRFMSB_920							0xE6
-#define RF_FRFMID_920							0x00
-#define RF_FRFLSB_920							0x00
-#define RF_FRFMSB_921							0xE6
-#define RF_FRFMID_921							0x40
-#define RF_FRFLSB_921							0x00
-#define RF_FRFMSB_922							0xE6
-#define RF_FRFMID_922							0x80
-#define RF_FRFLSB_922							0x00
-#define RF_FRFMSB_923							0xE6
-#define RF_FRFMID_923							0xC0
-#define RF_FRFLSB_923							0x00
-#define RF_FRFMSB_924							0xE7
-#define RF_FRFMID_924							0x00
-#define RF_FRFLSB_924							0x00
-#define RF_FRFMSB_925							0xE7
-#define RF_FRFMID_925							0x40
-#define RF_FRFLSB_925							0x00
-#define RF_FRFMSB_926							0xE7
-#define RF_FRFMID_926							0x80
-#define RF_FRFLSB_926							0x00
-#define RF_FRFMSB_927							0xE7
-#define RF_FRFMID_927							0xC0
-#define RF_FRFLSB_927							0x00
-#define RF_FRFMSB_928							0xE8
-#define RF_FRFMID_928							0x00
-#define RF_FRFLSB_928							0x00
+#define RF_FRFMSB_902             0xE1
+#define RF_FRFMID_902             0x80
+#define RF_FRFLSB_902             0x00
+#define RF_FRFMSB_903             0xE1
+#define RF_FRFMID_903             0xC0
+#define RF_FRFLSB_903             0x00
+#define RF_FRFMSB_904             0xE2
+#define RF_FRFMID_904             0x00
+#define RF_FRFLSB_904             0x00
+#define RF_FRFMSB_905             0xE2
+#define RF_FRFMID_905             0x40
+#define RF_FRFLSB_905             0x00
+#define RF_FRFMSB_906             0xE2
+#define RF_FRFMID_906             0x80
+#define RF_FRFLSB_906             0x00
+#define RF_FRFMSB_907             0xE2
+#define RF_FRFMID_907             0xC0
+#define RF_FRFLSB_907             0x00
+#define RF_FRFMSB_908             0xE3
+#define RF_FRFMID_908             0x00
+#define RF_FRFLSB_908             0x00
+#define RF_FRFMSB_909             0xE3
+#define RF_FRFMID_909             0x40
+#define RF_FRFLSB_909             0x00
+#define RF_FRFMSB_910             0xE3
+#define RF_FRFMID_910             0x80
+#define RF_FRFLSB_910             0x00
+#define RF_FRFMSB_911             0xE3
+#define RF_FRFMID_911             0xC0
+#define RF_FRFLSB_911             0x00
+#define RF_FRFMSB_912             0xE4
+#define RF_FRFMID_912             0x00
+#define RF_FRFLSB_912             0x00
+#define RF_FRFMSB_913             0xE4
+#define RF_FRFMID_913             0x40
+#define RF_FRFLSB_913             0x00
+#define RF_FRFMSB_914             0xE4
+#define RF_FRFMID_914             0x80
+#define RF_FRFLSB_914             0x00
+#define RF_FRFMSB_915             0xE4  // Default
+#define RF_FRFMID_915             0xC0  // Default
+#define RF_FRFLSB_915             0x00  // Default
+#define RF_FRFMSB_916             0xE5
+#define RF_FRFMID_916             0x00
+#define RF_FRFLSB_916             0x00
+#define RF_FRFMSB_917             0xE5
+#define RF_FRFMID_917             0x40
+#define RF_FRFLSB_917             0x00
+#define RF_FRFMSB_918             0xE5
+#define RF_FRFMID_918             0x80
+#define RF_FRFLSB_918             0x00
+#define RF_FRFMSB_919             0xE5
+#define RF_FRFMID_919             0xC0
+#define RF_FRFLSB_919             0x00
+#define RF_FRFMSB_920             0xE6
+#define RF_FRFMID_920             0x00
+#define RF_FRFLSB_920             0x00
+#define RF_FRFMSB_921             0xE6
+#define RF_FRFMID_921             0x40
+#define RF_FRFLSB_921             0x00
+#define RF_FRFMSB_922             0xE6
+#define RF_FRFMID_922             0x80
+#define RF_FRFLSB_922             0x00
+#define RF_FRFMSB_923             0xE6
+#define RF_FRFMID_923             0xC0
+#define RF_FRFLSB_923             0x00
+#define RF_FRFMSB_924             0xE7
+#define RF_FRFMID_924             0x00
+#define RF_FRFLSB_924             0x00
+#define RF_FRFMSB_925             0xE7
+#define RF_FRFMID_925             0x40
+#define RF_FRFLSB_925             0x00
+#define RF_FRFMSB_926             0xE7
+#define RF_FRFMID_926             0x80
+#define RF_FRFLSB_926             0x00
+#define RF_FRFMSB_927             0xE7
+#define RF_FRFMID_927             0xC0
+#define RF_FRFLSB_927             0x00
+#define RF_FRFMSB_928             0xE8
+#define RF_FRFMID_928             0x00
+#define RF_FRFLSB_928             0x00
 
 
 // RegOsc1
-#define RF_OSC1_RCCAL_START				0x80
-#define RF_OSC1_RCCAL_DONE				0x40
+#define RF_OSC1_RCCAL_START       0x80
+#define RF_OSC1_RCCAL_DONE        0x40
 
 // RegLowBat
-#define RF_LOWBAT_MONITOR					0x10
-#define RF_LOWBAT_ON							0x08
-#define RF_LOWBAT_OFF							0x00  // Default
+#define RF_LOWBAT_MONITOR         0x10
+#define RF_LOWBAT_ON              0x08
+#define RF_LOWBAT_OFF             0x00  // Default
 
-#define RF_LOWBAT_TRIM_1695				0x00
-#define RF_LOWBAT_TRIM_1764				0x01
-#define RF_LOWBAT_TRIM_1835				0x02  // Default
-#define RF_LOWBAT_TRIM_1905				0x03
-#define RF_LOWBAT_TRIM_1976				0x04
-#define RF_LOWBAT_TRIM_2045				0x05
-#define RF_LOWBAT_TRIM_2116				0x06
-#define RF_LOWBAT_TRIM_2185				0x07
+#define RF_LOWBAT_TRIM_1695       0x00
+#define RF_LOWBAT_TRIM_1764       0x01
+#define RF_LOWBAT_TRIM_1835       0x02  // Default
+#define RF_LOWBAT_TRIM_1905       0x03
+#define RF_LOWBAT_TRIM_1976       0x04
+#define RF_LOWBAT_TRIM_2045       0x05
+#define RF_LOWBAT_TRIM_2116       0x06
+#define RF_LOWBAT_TRIM_2185       0x07
 
 
 // RegListen1
-#define RF_LISTEN1_RESOL_64				0x50
-#define RF_LISTEN1_RESOL_4100			0xA0  // Default
-#define RF_LISTEN1_RESOL_262000		0xF0
+#define RF_LISTEN1_RESOL_64       0x50
+#define RF_LISTEN1_RESOL_4100     0xA0  // Default
+#define RF_LISTEN1_RESOL_262000   0xF0
 
-#define RF_LISTEN1_CRITERIA_RSSI				  0x00  // Default
-#define RF_LISTEN1_CRITERIA_RSSIANDSYNC	  0x08
+#define RF_LISTEN1_CRITERIA_RSSI          0x00  // Default
+#define RF_LISTEN1_CRITERIA_RSSIANDSYNC   0x08
 
-#define RF_LISTEN1_END_00						      0x00
-#define RF_LISTEN1_END_01						      0x02  // Default
-#define RF_LISTEN1_END_10						      0x04
+#define RF_LISTEN1_END_00                 0x00
+#define RF_LISTEN1_END_01                 0x02  // Default
+#define RF_LISTEN1_END_10                 0x04
 
 
 // RegListen2
-#define RF_LISTEN2_COEFIDLE_VALUE				0xF5 // Default
+#define RF_LISTEN2_COEFIDLE_VALUE         0xF5 // Default
 
 // RegListen3
-#define RF_LISTEN3_COEFRX_VALUE					0x20 // Default
+#define RF_LISTEN3_COEFRX_VALUE           0x20 // Default
 
 // RegPaLevel
-#define RF_PALEVEL_PA0_ON		  0x80  // Default
-#define RF_PALEVEL_PA0_OFF		0x00
-#define RF_PALEVEL_PA1_ON			0x40
-#define RF_PALEVEL_PA1_OFF		0x00  // Default
-#define RF_PALEVEL_PA2_ON			0x20
-#define RF_PALEVEL_PA2_OFF		0x00  // Default
+#define RF_PALEVEL_PA0_ON     0x80  // Default
+#define RF_PALEVEL_PA0_OFF    0x00
+#define RF_PALEVEL_PA1_ON     0x40
+#define RF_PALEVEL_PA1_OFF    0x00  // Default
+#define RF_PALEVEL_PA2_ON     0x20
+#define RF_PALEVEL_PA2_OFF    0x00  // Default
 
-#define RF_PALEVEL_OUTPUTPOWER_00000			0x00
-#define RF_PALEVEL_OUTPUTPOWER_00001			0x01
-#define RF_PALEVEL_OUTPUTPOWER_00010			0x02
-#define RF_PALEVEL_OUTPUTPOWER_00011			0x03
-#define RF_PALEVEL_OUTPUTPOWER_00100			0x04
-#define RF_PALEVEL_OUTPUTPOWER_00101			0x05
-#define RF_PALEVEL_OUTPUTPOWER_00110			0x06
-#define RF_PALEVEL_OUTPUTPOWER_00111			0x07
-#define RF_PALEVEL_OUTPUTPOWER_01000			0x08
-#define RF_PALEVEL_OUTPUTPOWER_01001			0x09
-#define RF_PALEVEL_OUTPUTPOWER_01010			0x0A
-#define RF_PALEVEL_OUTPUTPOWER_01011			0x0B
-#define RF_PALEVEL_OUTPUTPOWER_01100			0x0C
-#define RF_PALEVEL_OUTPUTPOWER_01101			0x0D
-#define RF_PALEVEL_OUTPUTPOWER_01110			0x0E
-#define RF_PALEVEL_OUTPUTPOWER_01111			0x0F
-#define RF_PALEVEL_OUTPUTPOWER_10000			0x10
-#define RF_PALEVEL_OUTPUTPOWER_10001			0x11
-#define RF_PALEVEL_OUTPUTPOWER_10010			0x12
-#define RF_PALEVEL_OUTPUTPOWER_10011			0x13
-#define RF_PALEVEL_OUTPUTPOWER_10100			0x14
-#define RF_PALEVEL_OUTPUTPOWER_10101			0x15
-#define RF_PALEVEL_OUTPUTPOWER_10110			0x16
-#define RF_PALEVEL_OUTPUTPOWER_10111			0x17
-#define RF_PALEVEL_OUTPUTPOWER_11000			0x18
-#define RF_PALEVEL_OUTPUTPOWER_11001			0x19
-#define RF_PALEVEL_OUTPUTPOWER_11010			0x1A
-#define RF_PALEVEL_OUTPUTPOWER_11011			0x1B
-#define RF_PALEVEL_OUTPUTPOWER_11100			0x1C
-#define RF_PALEVEL_OUTPUTPOWER_11101			0x1D
-#define RF_PALEVEL_OUTPUTPOWER_11110			0x1E
-#define RF_PALEVEL_OUTPUTPOWER_11111			0x1F  // Default
+#define RF_PALEVEL_OUTPUTPOWER_00000      0x00
+#define RF_PALEVEL_OUTPUTPOWER_00001      0x01
+#define RF_PALEVEL_OUTPUTPOWER_00010      0x02
+#define RF_PALEVEL_OUTPUTPOWER_00011      0x03
+#define RF_PALEVEL_OUTPUTPOWER_00100      0x04
+#define RF_PALEVEL_OUTPUTPOWER_00101      0x05
+#define RF_PALEVEL_OUTPUTPOWER_00110      0x06
+#define RF_PALEVEL_OUTPUTPOWER_00111      0x07
+#define RF_PALEVEL_OUTPUTPOWER_01000      0x08
+#define RF_PALEVEL_OUTPUTPOWER_01001      0x09
+#define RF_PALEVEL_OUTPUTPOWER_01010      0x0A
+#define RF_PALEVEL_OUTPUTPOWER_01011      0x0B
+#define RF_PALEVEL_OUTPUTPOWER_01100      0x0C
+#define RF_PALEVEL_OUTPUTPOWER_01101      0x0D
+#define RF_PALEVEL_OUTPUTPOWER_01110      0x0E
+#define RF_PALEVEL_OUTPUTPOWER_01111      0x0F
+#define RF_PALEVEL_OUTPUTPOWER_10000      0x10
+#define RF_PALEVEL_OUTPUTPOWER_10001      0x11
+#define RF_PALEVEL_OUTPUTPOWER_10010      0x12
+#define RF_PALEVEL_OUTPUTPOWER_10011      0x13
+#define RF_PALEVEL_OUTPUTPOWER_10100      0x14
+#define RF_PALEVEL_OUTPUTPOWER_10101      0x15
+#define RF_PALEVEL_OUTPUTPOWER_10110      0x16
+#define RF_PALEVEL_OUTPUTPOWER_10111      0x17
+#define RF_PALEVEL_OUTPUTPOWER_11000      0x18
+#define RF_PALEVEL_OUTPUTPOWER_11001      0x19
+#define RF_PALEVEL_OUTPUTPOWER_11010      0x1A
+#define RF_PALEVEL_OUTPUTPOWER_11011      0x1B
+#define RF_PALEVEL_OUTPUTPOWER_11100      0x1C
+#define RF_PALEVEL_OUTPUTPOWER_11101      0x1D
+#define RF_PALEVEL_OUTPUTPOWER_11110      0x1E
+#define RF_PALEVEL_OUTPUTPOWER_11111      0x1F  // Default
 
 
 // RegPaRamp
-#define RF_PARAMP_3400						0x00
-#define RF_PARAMP_2000						0x01
-#define RF_PARAMP_1000						0x02
-#define RF_PARAMP_500							0x03
-#define RF_PARAMP_250							0x04
-#define RF_PARAMP_125							0x05
-#define RF_PARAMP_100							0x06
-#define RF_PARAMP_62							0x07
-#define RF_PARAMP_50							0x08
-#define RF_PARAMP_40							0x09  // Default
-#define RF_PARAMP_31							0x0A
-#define RF_PARAMP_25							0x0B
-#define RF_PARAMP_20							0x0C
-#define RF_PARAMP_15							0x0D
-#define RF_PARAMP_12							0x0E
-#define RF_PARAMP_10							0x0F
+#define RF_PARAMP_3400            0x00
+#define RF_PARAMP_2000            0x01
+#define RF_PARAMP_1000            0x02
+#define RF_PARAMP_500             0x03
+#define RF_PARAMP_250             0x04
+#define RF_PARAMP_125             0x05
+#define RF_PARAMP_100             0x06
+#define RF_PARAMP_62              0x07
+#define RF_PARAMP_50              0x08
+#define RF_PARAMP_40              0x09  // Default
+#define RF_PARAMP_31              0x0A
+#define RF_PARAMP_25              0x0B
+#define RF_PARAMP_20              0x0C
+#define RF_PARAMP_15              0x0D
+#define RF_PARAMP_12              0x0E
+#define RF_PARAMP_10              0x0F
 
 
 // RegOcp
-#define RF_OCP_OFF								0x0F
-#define RF_OCP_ON								  0x1A  // Default
+#define RF_OCP_OFF                0x0F
+#define RF_OCP_ON                 0x1A  // Default
 
-#define RF_OCP_TRIM_45						0x00
-#define RF_OCP_TRIM_50						0x01
-#define RF_OCP_TRIM_55						0x02
-#define RF_OCP_TRIM_60						0x03
-#define RF_OCP_TRIM_65						0x04
-#define RF_OCP_TRIM_70						0x05
-#define RF_OCP_TRIM_75						0x06
-#define RF_OCP_TRIM_80						0x07
-#define RF_OCP_TRIM_85						0x08
-#define RF_OCP_TRIM_90						0x09
-#define RF_OCP_TRIM_95						0x0A
-#define RF_OCP_TRIM_100						0x0B  // Default
-#define RF_OCP_TRIM_105						0x0C
-#define RF_OCP_TRIM_110						0x0D
-#define RF_OCP_TRIM_115						0x0E
-#define RF_OCP_TRIM_120						0x0F
+#define RF_OCP_TRIM_45            0x00
+#define RF_OCP_TRIM_50            0x01
+#define RF_OCP_TRIM_55            0x02
+#define RF_OCP_TRIM_60            0x03
+#define RF_OCP_TRIM_65            0x04
+#define RF_OCP_TRIM_70            0x05
+#define RF_OCP_TRIM_75            0x06
+#define RF_OCP_TRIM_80            0x07
+#define RF_OCP_TRIM_85            0x08
+#define RF_OCP_TRIM_90            0x09
+#define RF_OCP_TRIM_95            0x0A
+#define RF_OCP_TRIM_100           0x0B  // Default
+#define RF_OCP_TRIM_105           0x0C
+#define RF_OCP_TRIM_110           0x0D
+#define RF_OCP_TRIM_115           0x0E
+#define RF_OCP_TRIM_120           0x0F
 
 
 // RegAgcRef
-#define RF_AGCREF_AUTO_ON					0x40  // Default
-#define RF_AGCREF_AUTO_OFF				0x00
+#define RF_AGCREF_AUTO_ON         0x40  // Default
+#define RF_AGCREF_AUTO_OFF        0x00
 
-#define RF_AGCREF_LEVEL_MINUS80		0x00  // Default
-#define RF_AGCREF_LEVEL_MINUS81		0x01
-#define RF_AGCREF_LEVEL_MINUS82		0x02
-#define RF_AGCREF_LEVEL_MINUS83		0x03
-#define RF_AGCREF_LEVEL_MINUS84		0x04
-#define RF_AGCREF_LEVEL_MINUS85		0x05
-#define RF_AGCREF_LEVEL_MINUS86		0x06
-#define RF_AGCREF_LEVEL_MINUS87		0x07
-#define RF_AGCREF_LEVEL_MINUS88		0x08
-#define RF_AGCREF_LEVEL_MINUS89		0x09
-#define RF_AGCREF_LEVEL_MINUS90		0x0A
-#define RF_AGCREF_LEVEL_MINUS91		0x0B
-#define RF_AGCREF_LEVEL_MINUS92		0x0C
-#define RF_AGCREF_LEVEL_MINUS93		0x0D
-#define RF_AGCREF_LEVEL_MINUS94		0x0E
-#define RF_AGCREF_LEVEL_MINUS95		0x0F
-#define RF_AGCREF_LEVEL_MINUS96		0x10
-#define RF_AGCREF_LEVEL_MINUS97		0x11
-#define RF_AGCREF_LEVEL_MINUS98		0x12
-#define RF_AGCREF_LEVEL_MINUS99		0x13
-#define RF_AGCREF_LEVEL_MINUS100	0x14
-#define RF_AGCREF_LEVEL_MINUS101	0x15
-#define RF_AGCREF_LEVEL_MINUS102	0x16
-#define RF_AGCREF_LEVEL_MINUS103	0x17
-#define RF_AGCREF_LEVEL_MINUS104	0x18
-#define RF_AGCREF_LEVEL_MINUS105	0x19
-#define RF_AGCREF_LEVEL_MINUS106	0x1A
-#define RF_AGCREF_LEVEL_MINUS107	0x1B
-#define RF_AGCREF_LEVEL_MINUS108	0x1C
-#define RF_AGCREF_LEVEL_MINUS109	0x1D
-#define RF_AGCREF_LEVEL_MINUS110	0x1E
-#define RF_AGCREF_LEVEL_MINUS111	0x1F
-#define RF_AGCREF_LEVEL_MINUS112	0x20
-#define RF_AGCREF_LEVEL_MINUS113	0x21
-#define RF_AGCREF_LEVEL_MINUS114	0x22
-#define RF_AGCREF_LEVEL_MINUS115	0x23
-#define RF_AGCREF_LEVEL_MINUS116	0x24
-#define RF_AGCREF_LEVEL_MINUS117	0x25
-#define RF_AGCREF_LEVEL_MINUS118	0x26
-#define RF_AGCREF_LEVEL_MINUS119	0x27
-#define RF_AGCREF_LEVEL_MINUS120	0x28
-#define RF_AGCREF_LEVEL_MINUS121	0x29
-#define RF_AGCREF_LEVEL_MINUS122	0x2A
-#define RF_AGCREF_LEVEL_MINUS123	0x2B
-#define RF_AGCREF_LEVEL_MINUS124	0x2C
-#define RF_AGCREF_LEVEL_MINUS125	0x2D
-#define RF_AGCREF_LEVEL_MINUS126	0x2E
-#define RF_AGCREF_LEVEL_MINUS127	0x2F
-#define RF_AGCREF_LEVEL_MINUS128	0x30
-#define RF_AGCREF_LEVEL_MINUS129	0x31
-#define RF_AGCREF_LEVEL_MINUS130	0x32
-#define RF_AGCREF_LEVEL_MINUS131	0x33
-#define RF_AGCREF_LEVEL_MINUS132	0x34
-#define RF_AGCREF_LEVEL_MINUS133	0x35
-#define RF_AGCREF_LEVEL_MINUS134	0x36
-#define RF_AGCREF_LEVEL_MINUS135	0x37
-#define RF_AGCREF_LEVEL_MINUS136	0x38
-#define RF_AGCREF_LEVEL_MINUS137	0x39
-#define RF_AGCREF_LEVEL_MINUS138	0x3A
-#define RF_AGCREF_LEVEL_MINUS139	0x3B
-#define RF_AGCREF_LEVEL_MINUS140	0x3C
-#define RF_AGCREF_LEVEL_MINUS141	0x3D
-#define RF_AGCREF_LEVEL_MINUS142	0x3E
-#define RF_AGCREF_LEVEL_MINUS143	0x3F
+#define RF_AGCREF_LEVEL_MINUS80   0x00  // Default
+#define RF_AGCREF_LEVEL_MINUS81   0x01
+#define RF_AGCREF_LEVEL_MINUS82   0x02
+#define RF_AGCREF_LEVEL_MINUS83   0x03
+#define RF_AGCREF_LEVEL_MINUS84   0x04
+#define RF_AGCREF_LEVEL_MINUS85   0x05
+#define RF_AGCREF_LEVEL_MINUS86   0x06
+#define RF_AGCREF_LEVEL_MINUS87   0x07
+#define RF_AGCREF_LEVEL_MINUS88   0x08
+#define RF_AGCREF_LEVEL_MINUS89   0x09
+#define RF_AGCREF_LEVEL_MINUS90   0x0A
+#define RF_AGCREF_LEVEL_MINUS91   0x0B
+#define RF_AGCREF_LEVEL_MINUS92   0x0C
+#define RF_AGCREF_LEVEL_MINUS93   0x0D
+#define RF_AGCREF_LEVEL_MINUS94   0x0E
+#define RF_AGCREF_LEVEL_MINUS95   0x0F
+#define RF_AGCREF_LEVEL_MINUS96   0x10
+#define RF_AGCREF_LEVEL_MINUS97   0x11
+#define RF_AGCREF_LEVEL_MINUS98   0x12
+#define RF_AGCREF_LEVEL_MINUS99   0x13
+#define RF_AGCREF_LEVEL_MINUS100  0x14
+#define RF_AGCREF_LEVEL_MINUS101  0x15
+#define RF_AGCREF_LEVEL_MINUS102  0x16
+#define RF_AGCREF_LEVEL_MINUS103  0x17
+#define RF_AGCREF_LEVEL_MINUS104  0x18
+#define RF_AGCREF_LEVEL_MINUS105  0x19
+#define RF_AGCREF_LEVEL_MINUS106  0x1A
+#define RF_AGCREF_LEVEL_MINUS107  0x1B
+#define RF_AGCREF_LEVEL_MINUS108  0x1C
+#define RF_AGCREF_LEVEL_MINUS109  0x1D
+#define RF_AGCREF_LEVEL_MINUS110  0x1E
+#define RF_AGCREF_LEVEL_MINUS111  0x1F
+#define RF_AGCREF_LEVEL_MINUS112  0x20
+#define RF_AGCREF_LEVEL_MINUS113  0x21
+#define RF_AGCREF_LEVEL_MINUS114  0x22
+#define RF_AGCREF_LEVEL_MINUS115  0x23
+#define RF_AGCREF_LEVEL_MINUS116  0x24
+#define RF_AGCREF_LEVEL_MINUS117  0x25
+#define RF_AGCREF_LEVEL_MINUS118  0x26
+#define RF_AGCREF_LEVEL_MINUS119  0x27
+#define RF_AGCREF_LEVEL_MINUS120  0x28
+#define RF_AGCREF_LEVEL_MINUS121  0x29
+#define RF_AGCREF_LEVEL_MINUS122  0x2A
+#define RF_AGCREF_LEVEL_MINUS123  0x2B
+#define RF_AGCREF_LEVEL_MINUS124  0x2C
+#define RF_AGCREF_LEVEL_MINUS125  0x2D
+#define RF_AGCREF_LEVEL_MINUS126  0x2E
+#define RF_AGCREF_LEVEL_MINUS127  0x2F
+#define RF_AGCREF_LEVEL_MINUS128  0x30
+#define RF_AGCREF_LEVEL_MINUS129  0x31
+#define RF_AGCREF_LEVEL_MINUS130  0x32
+#define RF_AGCREF_LEVEL_MINUS131  0x33
+#define RF_AGCREF_LEVEL_MINUS132  0x34
+#define RF_AGCREF_LEVEL_MINUS133  0x35
+#define RF_AGCREF_LEVEL_MINUS134  0x36
+#define RF_AGCREF_LEVEL_MINUS135  0x37
+#define RF_AGCREF_LEVEL_MINUS136  0x38
+#define RF_AGCREF_LEVEL_MINUS137  0x39
+#define RF_AGCREF_LEVEL_MINUS138  0x3A
+#define RF_AGCREF_LEVEL_MINUS139  0x3B
+#define RF_AGCREF_LEVEL_MINUS140  0x3C
+#define RF_AGCREF_LEVEL_MINUS141  0x3D
+#define RF_AGCREF_LEVEL_MINUS142  0x3E
+#define RF_AGCREF_LEVEL_MINUS143  0x3F
 
 
 // RegAgcThresh1
-#define RF_AGCTHRESH1_SNRMARGIN_000		0x00
-#define RF_AGCTHRESH1_SNRMARGIN_001		0x20
-#define RF_AGCTHRESH1_SNRMARGIN_010		0x40
-#define RF_AGCTHRESH1_SNRMARGIN_011		0x60
-#define RF_AGCTHRESH1_SNRMARGIN_100		0x80
-#define RF_AGCTHRESH1_SNRMARGIN_101		0xA0  // Default
-#define RF_AGCTHRESH1_SNRMARGIN_110		0xC0
-#define RF_AGCTHRESH1_SNRMARGIN_111		0xE0
+#define RF_AGCTHRESH1_SNRMARGIN_000   0x00
+#define RF_AGCTHRESH1_SNRMARGIN_001   0x20
+#define RF_AGCTHRESH1_SNRMARGIN_010   0x40
+#define RF_AGCTHRESH1_SNRMARGIN_011   0x60
+#define RF_AGCTHRESH1_SNRMARGIN_100   0x80
+#define RF_AGCTHRESH1_SNRMARGIN_101   0xA0  // Default
+#define RF_AGCTHRESH1_SNRMARGIN_110   0xC0
+#define RF_AGCTHRESH1_SNRMARGIN_111   0xE0
 
-#define RF_AGCTHRESH1_STEP1_0					0x00
-#define RF_AGCTHRESH1_STEP1_1					0x01
-#define RF_AGCTHRESH1_STEP1_2					0x02
-#define RF_AGCTHRESH1_STEP1_3					0x03
-#define RF_AGCTHRESH1_STEP1_4					0x04
-#define RF_AGCTHRESH1_STEP1_5					0x05
-#define RF_AGCTHRESH1_STEP1_6					0x06
-#define RF_AGCTHRESH1_STEP1_7					0x07
-#define RF_AGCTHRESH1_STEP1_8					0x08
-#define RF_AGCTHRESH1_STEP1_9					0x09
-#define RF_AGCTHRESH1_STEP1_10				0x0A
-#define RF_AGCTHRESH1_STEP1_11				0x0B
-#define RF_AGCTHRESH1_STEP1_12				0x0C
-#define RF_AGCTHRESH1_STEP1_13				0x0D
-#define RF_AGCTHRESH1_STEP1_14				0x0E
-#define RF_AGCTHRESH1_STEP1_15				0x0F
-#define RF_AGCTHRESH1_STEP1_16				0x10  // Default
-#define RF_AGCTHRESH1_STEP1_17				0x11
-#define RF_AGCTHRESH1_STEP1_18				0x12
-#define RF_AGCTHRESH1_STEP1_19				0x13
-#define RF_AGCTHRESH1_STEP1_20				0x14
-#define RF_AGCTHRESH1_STEP1_21				0x15
-#define RF_AGCTHRESH1_STEP1_22				0x16
-#define RF_AGCTHRESH1_STEP1_23				0x17
-#define RF_AGCTHRESH1_STEP1_24				0x18
-#define RF_AGCTHRESH1_STEP1_25				0x19
-#define RF_AGCTHRESH1_STEP1_26				0x1A
-#define RF_AGCTHRESH1_STEP1_27				0x1B
-#define RF_AGCTHRESH1_STEP1_28				0x1C
-#define RF_AGCTHRESH1_STEP1_29				0x1D
-#define RF_AGCTHRESH1_STEP1_30				0x1E
-#define RF_AGCTHRESH1_STEP1_31				0x1F
+#define RF_AGCTHRESH1_STEP1_0         0x00
+#define RF_AGCTHRESH1_STEP1_1         0x01
+#define RF_AGCTHRESH1_STEP1_2         0x02
+#define RF_AGCTHRESH1_STEP1_3         0x03
+#define RF_AGCTHRESH1_STEP1_4         0x04
+#define RF_AGCTHRESH1_STEP1_5         0x05
+#define RF_AGCTHRESH1_STEP1_6         0x06
+#define RF_AGCTHRESH1_STEP1_7         0x07
+#define RF_AGCTHRESH1_STEP1_8         0x08
+#define RF_AGCTHRESH1_STEP1_9         0x09
+#define RF_AGCTHRESH1_STEP1_10        0x0A
+#define RF_AGCTHRESH1_STEP1_11        0x0B
+#define RF_AGCTHRESH1_STEP1_12        0x0C
+#define RF_AGCTHRESH1_STEP1_13        0x0D
+#define RF_AGCTHRESH1_STEP1_14        0x0E
+#define RF_AGCTHRESH1_STEP1_15        0x0F
+#define RF_AGCTHRESH1_STEP1_16        0x10  // Default
+#define RF_AGCTHRESH1_STEP1_17        0x11
+#define RF_AGCTHRESH1_STEP1_18        0x12
+#define RF_AGCTHRESH1_STEP1_19        0x13
+#define RF_AGCTHRESH1_STEP1_20        0x14
+#define RF_AGCTHRESH1_STEP1_21        0x15
+#define RF_AGCTHRESH1_STEP1_22        0x16
+#define RF_AGCTHRESH1_STEP1_23        0x17
+#define RF_AGCTHRESH1_STEP1_24        0x18
+#define RF_AGCTHRESH1_STEP1_25        0x19
+#define RF_AGCTHRESH1_STEP1_26        0x1A
+#define RF_AGCTHRESH1_STEP1_27        0x1B
+#define RF_AGCTHRESH1_STEP1_28        0x1C
+#define RF_AGCTHRESH1_STEP1_29        0x1D
+#define RF_AGCTHRESH1_STEP1_30        0x1E
+#define RF_AGCTHRESH1_STEP1_31        0x1F
 
 
 // RegAgcThresh2
-#define RF_AGCTHRESH2_STEP2_0					0x00
-#define RF_AGCTHRESH2_STEP2_1					0x10
-#define RF_AGCTHRESH2_STEP2_2					0x20
-#define RF_AGCTHRESH2_STEP2_3					0x30  // XXX wrong -- Default
-#define RF_AGCTHRESH2_STEP2_4					0x40
-#define RF_AGCTHRESH2_STEP2_5					0x50
-#define RF_AGCTHRESH2_STEP2_6					0x60
-#define RF_AGCTHRESH2_STEP2_7					0x70	// default
-#define RF_AGCTHRESH2_STEP2_8					0x80
-#define RF_AGCTHRESH2_STEP2_9					0x90
-#define RF_AGCTHRESH2_STEP2_10				0xA0
-#define RF_AGCTHRESH2_STEP2_11				0xB0
-#define RF_AGCTHRESH2_STEP2_12				0xC0
-#define RF_AGCTHRESH2_STEP2_13				0xD0
-#define RF_AGCTHRESH2_STEP2_14				0xE0
-#define RF_AGCTHRESH2_STEP2_15				0xF0
+#define RF_AGCTHRESH2_STEP2_0         0x00
+#define RF_AGCTHRESH2_STEP2_1         0x10
+#define RF_AGCTHRESH2_STEP2_2         0x20
+#define RF_AGCTHRESH2_STEP2_3         0x30  // XXX wrong -- Default
+#define RF_AGCTHRESH2_STEP2_4         0x40
+#define RF_AGCTHRESH2_STEP2_5         0x50
+#define RF_AGCTHRESH2_STEP2_6         0x60
+#define RF_AGCTHRESH2_STEP2_7         0x70  // default
+#define RF_AGCTHRESH2_STEP2_8         0x80
+#define RF_AGCTHRESH2_STEP2_9         0x90
+#define RF_AGCTHRESH2_STEP2_10        0xA0
+#define RF_AGCTHRESH2_STEP2_11        0xB0
+#define RF_AGCTHRESH2_STEP2_12        0xC0
+#define RF_AGCTHRESH2_STEP2_13        0xD0
+#define RF_AGCTHRESH2_STEP2_14        0xE0
+#define RF_AGCTHRESH2_STEP2_15        0xF0
 
-#define RF_AGCTHRESH2_STEP3_0					0x00
-#define RF_AGCTHRESH2_STEP3_1					0x01
-#define RF_AGCTHRESH2_STEP3_2					0x02
-#define RF_AGCTHRESH2_STEP3_3					0x03
-#define RF_AGCTHRESH2_STEP3_4					0x04
-#define RF_AGCTHRESH2_STEP3_5					0x05
-#define RF_AGCTHRESH2_STEP3_6					0x06
-#define RF_AGCTHRESH2_STEP3_7					0x07
-#define RF_AGCTHRESH2_STEP3_8					0x08
-#define RF_AGCTHRESH2_STEP3_9					0x09
-#define RF_AGCTHRESH2_STEP3_10				0x0A
-#define RF_AGCTHRESH2_STEP3_11				0x0B  // Default
-#define RF_AGCTHRESH2_STEP3_12				0x0C
-#define RF_AGCTHRESH2_STEP3_13				0x0D
-#define RF_AGCTHRESH2_STEP3_14				0x0E
-#define RF_AGCTHRESH2_STEP3_15				0x0F
+#define RF_AGCTHRESH2_STEP3_0         0x00
+#define RF_AGCTHRESH2_STEP3_1         0x01
+#define RF_AGCTHRESH2_STEP3_2         0x02
+#define RF_AGCTHRESH2_STEP3_3         0x03
+#define RF_AGCTHRESH2_STEP3_4         0x04
+#define RF_AGCTHRESH2_STEP3_5         0x05
+#define RF_AGCTHRESH2_STEP3_6         0x06
+#define RF_AGCTHRESH2_STEP3_7         0x07
+#define RF_AGCTHRESH2_STEP3_8         0x08
+#define RF_AGCTHRESH2_STEP3_9         0x09
+#define RF_AGCTHRESH2_STEP3_10        0x0A
+#define RF_AGCTHRESH2_STEP3_11        0x0B  // Default
+#define RF_AGCTHRESH2_STEP3_12        0x0C
+#define RF_AGCTHRESH2_STEP3_13        0x0D
+#define RF_AGCTHRESH2_STEP3_14        0x0E
+#define RF_AGCTHRESH2_STEP3_15        0x0F
 
 
 // RegAgcThresh3
-#define RF_AGCTHRESH3_STEP4_0					0x00
-#define RF_AGCTHRESH3_STEP4_1					0x10
-#define RF_AGCTHRESH3_STEP4_2					0x20
-#define RF_AGCTHRESH3_STEP4_3					0x30
-#define RF_AGCTHRESH3_STEP4_4					0x40
-#define RF_AGCTHRESH3_STEP4_5					0x50
-#define RF_AGCTHRESH3_STEP4_6					0x60
-#define RF_AGCTHRESH3_STEP4_7					0x70
-#define RF_AGCTHRESH3_STEP4_8					0x80
-#define RF_AGCTHRESH3_STEP4_9					0x90  // Default
-#define RF_AGCTHRESH3_STEP4_10				0xA0
-#define RF_AGCTHRESH3_STEP4_11				0xB0
-#define RF_AGCTHRESH3_STEP4_12				0xC0
-#define RF_AGCTHRESH3_STEP4_13				0xD0
-#define RF_AGCTHRESH3_STEP4_14				0xE0
-#define RF_AGCTHRESH3_STEP4_15				0xF0
+#define RF_AGCTHRESH3_STEP4_0         0x00
+#define RF_AGCTHRESH3_STEP4_1         0x10
+#define RF_AGCTHRESH3_STEP4_2         0x20
+#define RF_AGCTHRESH3_STEP4_3         0x30
+#define RF_AGCTHRESH3_STEP4_4         0x40
+#define RF_AGCTHRESH3_STEP4_5         0x50
+#define RF_AGCTHRESH3_STEP4_6         0x60
+#define RF_AGCTHRESH3_STEP4_7         0x70
+#define RF_AGCTHRESH3_STEP4_8         0x80
+#define RF_AGCTHRESH3_STEP4_9         0x90  // Default
+#define RF_AGCTHRESH3_STEP4_10        0xA0
+#define RF_AGCTHRESH3_STEP4_11        0xB0
+#define RF_AGCTHRESH3_STEP4_12        0xC0
+#define RF_AGCTHRESH3_STEP4_13        0xD0
+#define RF_AGCTHRESH3_STEP4_14        0xE0
+#define RF_AGCTHRESH3_STEP4_15        0xF0
 
-#define RF_AGCTHRESH3_STEP5_0					0x00
-#define RF_AGCTHRESH3_STEP5_1					0x01
-#define RF_AGCTHRESH3_STEP5_2					0x02
-#define RF_AGCTHRESH3_STEP5_3					0x03
-#define RF_AGCTHRESH3_STEP5_4					0x04
-#define RF_AGCTHRESH3_STEP5_5					0x05
-#define RF_AGCTHRESH3_STEP5_6					0x06
-#define RF_AGCTHRESH3_STEP5_7					0x07
-#define RF_AGCTHRES33_STEP5_8					0x08
-#define RF_AGCTHRESH3_STEP5_9					0x09
-#define RF_AGCTHRESH3_STEP5_10				0x0A
-#define RF_AGCTHRESH3_STEP5_11				0x0B  // Default
-#define RF_AGCTHRESH3_STEP5_12				0x0C
-#define RF_AGCTHRESH3_STEP5_13				0x0D
-#define RF_AGCTHRESH3_STEP5_14				0x0E
-#define RF_AGCTHRESH3_STEP5_15				0x0F
+#define RF_AGCTHRESH3_STEP5_0         0x00
+#define RF_AGCTHRESH3_STEP5_1         0x01
+#define RF_AGCTHRESH3_STEP5_2         0x02
+#define RF_AGCTHRESH3_STEP5_3         0x03
+#define RF_AGCTHRESH3_STEP5_4         0x04
+#define RF_AGCTHRESH3_STEP5_5         0x05
+#define RF_AGCTHRESH3_STEP5_6         0x06
+#define RF_AGCTHRESH3_STEP5_7         0x07
+#define RF_AGCTHRES33_STEP5_8         0x08
+#define RF_AGCTHRESH3_STEP5_9         0x09
+#define RF_AGCTHRESH3_STEP5_10        0x0A
+#define RF_AGCTHRESH3_STEP5_11        0x0B  // Default
+#define RF_AGCTHRESH3_STEP5_12        0x0C
+#define RF_AGCTHRESH3_STEP5_13        0x0D
+#define RF_AGCTHRESH3_STEP5_14        0x0E
+#define RF_AGCTHRESH3_STEP5_15        0x0F
 
 
 // RegLna
-#define RF_LNA_ZIN_50							    0x00
-#define RF_LNA_ZIN_200							  0x80  // Default
+#define RF_LNA_ZIN_50                 0x00
+#define RF_LNA_ZIN_200                0x80  // Default
 
-#define RF_LNA_LOWPOWER_OFF						0x00  // Default
-#define RF_LNA_LOWPOWER_ON						0x40
+#define RF_LNA_LOWPOWER_OFF           0x00  // Default
+#define RF_LNA_LOWPOWER_ON            0x40
 
-#define RF_LNA_CURRENTGAIN						0x08
+#define RF_LNA_CURRENTGAIN            0x08
 
-#define RF_LNA_GAINSELECT_AUTO				0x00  // Default
-#define RF_LNA_GAINSELECT_MAX					0x01
-#define RF_LNA_GAINSELECT_MAXMINUS6		0x02
-#define RF_LNA_GAINSELECT_MAXMINUS12	0x03
-#define RF_LNA_GAINSELECT_MAXMINUS24	0x04
-#define RF_LNA_GAINSELECT_MAXMINUS36	0x05
-#define RF_LNA_GAINSELECT_MAXMINUS48	0x06
+#define RF_LNA_GAINSELECT_AUTO        0x00  // Default
+#define RF_LNA_GAINSELECT_MAX         0x01
+#define RF_LNA_GAINSELECT_MAXMINUS6   0x02
+#define RF_LNA_GAINSELECT_MAXMINUS12  0x03
+#define RF_LNA_GAINSELECT_MAXMINUS24  0x04
+#define RF_LNA_GAINSELECT_MAXMINUS36  0x05
+#define RF_LNA_GAINSELECT_MAXMINUS48  0x06
 
 
 // RegRxBw
-#define RF_RXBW_DCCFREQ_000						0x00
-#define RF_RXBW_DCCFREQ_001						0x20
-#define RF_RXBW_DCCFREQ_010						0x40  // Default
-#define RF_RXBW_DCCFREQ_011						0x60
-#define RF_RXBW_DCCFREQ_100						0x80
-#define RF_RXBW_DCCFREQ_101						0xA0
-#define RF_RXBW_DCCFREQ_110						0xC0
-#define RF_RXBW_DCCFREQ_111						0xE0
+#define RF_RXBW_DCCFREQ_000           0x00
+#define RF_RXBW_DCCFREQ_001           0x20
+#define RF_RXBW_DCCFREQ_010           0x40  // Default
+#define RF_RXBW_DCCFREQ_011           0x60
+#define RF_RXBW_DCCFREQ_100           0x80
+#define RF_RXBW_DCCFREQ_101           0xA0
+#define RF_RXBW_DCCFREQ_110           0xC0
+#define RF_RXBW_DCCFREQ_111           0xE0
 
-#define RF_RXBW_MANT_16							  0x00
-#define RF_RXBW_MANT_20							  0x08
-#define RF_RXBW_MANT_24							  0x10  // Default
+#define RF_RXBW_MANT_16               0x00
+#define RF_RXBW_MANT_20               0x08
+#define RF_RXBW_MANT_24               0x10  // Default
 
-#define RF_RXBW_EXP_0							    0x00
-#define RF_RXBW_EXP_1		  			  		0x01
-#define RF_RXBW_EXP_2			  	  			0x02
-#define RF_RXBW_EXP_3				    			0x03
-#define RF_RXBW_EXP_4			  		  		0x04
-#define RF_RXBW_EXP_5		  				  	0x05  // Default
-#define RF_RXBW_EXP_6	  						  0x06
-#define RF_RXBW_EXP_7						  	  0x07
+#define RF_RXBW_EXP_0                 0x00
+#define RF_RXBW_EXP_1                 0x01
+#define RF_RXBW_EXP_2                 0x02
+#define RF_RXBW_EXP_3                 0x03
+#define RF_RXBW_EXP_4                 0x04
+#define RF_RXBW_EXP_5                 0x05  // Default
+#define RF_RXBW_EXP_6                 0x06
+#define RF_RXBW_EXP_7                 0x07
 
 
 // RegAfcBw
-#define RF_AFCBW_DCCFREQAFC_000				0x00
-#define RF_AFCBW_DCCFREQAFC_001				0x20
-#define RF_AFCBW_DCCFREQAFC_010				0x40
-#define RF_AFCBW_DCCFREQAFC_011				0x60
-#define RF_AFCBW_DCCFREQAFC_100				0x80  // Default
-#define RF_AFCBW_DCCFREQAFC_101				0xA0
-#define RF_AFCBW_DCCFREQAFC_110				0xC0
-#define RF_AFCBW_DCCFREQAFC_111				0xE0
+#define RF_AFCBW_DCCFREQAFC_000       0x00
+#define RF_AFCBW_DCCFREQAFC_001       0x20
+#define RF_AFCBW_DCCFREQAFC_010       0x40
+#define RF_AFCBW_DCCFREQAFC_011       0x60
+#define RF_AFCBW_DCCFREQAFC_100       0x80  // Default
+#define RF_AFCBW_DCCFREQAFC_101       0xA0
+#define RF_AFCBW_DCCFREQAFC_110       0xC0
+#define RF_AFCBW_DCCFREQAFC_111       0xE0
 
-#define RF_AFCBW_MANTAFC_16						0x00
-#define RF_AFCBW_MANTAFC_20						0x08  // Default
-#define RF_AFCBW_MANTAFC_24						0x10
+#define RF_AFCBW_MANTAFC_16           0x00
+#define RF_AFCBW_MANTAFC_20           0x08  // Default
+#define RF_AFCBW_MANTAFC_24           0x10
 
-#define RF_AFCBW_EXPAFC_0						  0x00
-#define RF_AFCBW_EXPAFC_1	  					0x01
-#define RF_AFCBW_EXPAFC_2		  				0x02
-#define RF_AFCBW_EXPAFC_3			  			0x03  // Default
-#define RF_AFCBW_EXPAFC_4				  		0x04
-#define RF_AFCBW_EXPAFC_5					  	0x05
-#define RF_AFCBW_EXPAFC_6						  0x06
-#define RF_AFCBW_EXPAFC_7					  	0x07
+#define RF_AFCBW_EXPAFC_0             0x00
+#define RF_AFCBW_EXPAFC_1             0x01
+#define RF_AFCBW_EXPAFC_2             0x02
+#define RF_AFCBW_EXPAFC_3             0x03  // Default
+#define RF_AFCBW_EXPAFC_4             0x04
+#define RF_AFCBW_EXPAFC_5             0x05
+#define RF_AFCBW_EXPAFC_6             0x06
+#define RF_AFCBW_EXPAFC_7             0x07
 
 
 // RegOokPeak
-#define RF_OOKPEAK_THRESHTYPE_FIXED				0x00
-#define RF_OOKPEAK_THRESHTYPE_PEAK				0x40  // Default
-#define RF_OOKPEAK_THRESHTYPE_AVERAGE			0x80
+#define RF_OOKPEAK_THRESHTYPE_FIXED       0x00
+#define RF_OOKPEAK_THRESHTYPE_PEAK        0x40  // Default
+#define RF_OOKPEAK_THRESHTYPE_AVERAGE     0x80
 
-#define RF_OOKPEAK_PEAKTHRESHSTEP_000			0x00  // Default
-#define RF_OOKPEAK_PEAKTHRESHSTEP_001			0x08
-#define RF_OOKPEAK_PEAKTHRESHSTEP_010			0x10
-#define RF_OOKPEAK_PEAKTHRESHSTEP_011			0x18
-#define RF_OOKPEAK_PEAKTHRESHSTEP_100			0x20
-#define RF_OOKPEAK_PEAKTHRESHSTEP_101			0x28
-#define RF_OOKPEAK_PEAKTHRESHSTEP_110			0x30
-#define RF_OOKPEAK_PEAKTHRESHSTEP_111			0x38
+#define RF_OOKPEAK_PEAKTHRESHSTEP_000     0x00  // Default
+#define RF_OOKPEAK_PEAKTHRESHSTEP_001     0x08
+#define RF_OOKPEAK_PEAKTHRESHSTEP_010     0x10
+#define RF_OOKPEAK_PEAKTHRESHSTEP_011     0x18
+#define RF_OOKPEAK_PEAKTHRESHSTEP_100     0x20
+#define RF_OOKPEAK_PEAKTHRESHSTEP_101     0x28
+#define RF_OOKPEAK_PEAKTHRESHSTEP_110     0x30
+#define RF_OOKPEAK_PEAKTHRESHSTEP_111     0x38
 
-#define RF_OOKPEAK_PEAKTHRESHDEC_000			0x00  // Default
-#define RF_OOKPEAK_PEAKTHRESHDEC_001			0x01
-#define RF_OOKPEAK_PEAKTHRESHDEC_010			0x02
-#define RF_OOKPEAK_PEAKTHRESHDEC_011			0x03
-#define RF_OOKPEAK_PEAKTHRESHDEC_100			0x04
-#define RF_OOKPEAK_PEAKTHRESHDEC_101			0x05
-#define RF_OOKPEAK_PEAKTHRESHDEC_110			0x06
-#define RF_OOKPEAK_PEAKTHRESHDEC_111			0x07
+#define RF_OOKPEAK_PEAKTHRESHDEC_000      0x00  // Default
+#define RF_OOKPEAK_PEAKTHRESHDEC_001      0x01
+#define RF_OOKPEAK_PEAKTHRESHDEC_010      0x02
+#define RF_OOKPEAK_PEAKTHRESHDEC_011      0x03
+#define RF_OOKPEAK_PEAKTHRESHDEC_100      0x04
+#define RF_OOKPEAK_PEAKTHRESHDEC_101      0x05
+#define RF_OOKPEAK_PEAKTHRESHDEC_110      0x06
+#define RF_OOKPEAK_PEAKTHRESHDEC_111      0x07
 
 
 // RegOokAvg
-#define RF_OOKAVG_AVERAGETHRESHFILT_00		0x00
-#define RF_OOKAVG_AVERAGETHRESHFILT_01		0x40
-#define RF_OOKAVG_AVERAGETHRESHFILT_10		0x80  // Default
-#define RF_OOKAVG_AVERAGETHRESHFILT_11		0xC0
+#define RF_OOKAVG_AVERAGETHRESHFILT_00    0x00
+#define RF_OOKAVG_AVERAGETHRESHFILT_01    0x40
+#define RF_OOKAVG_AVERAGETHRESHFILT_10    0x80  // Default
+#define RF_OOKAVG_AVERAGETHRESHFILT_11    0xC0
 
 
 // RegOokFix
-#define RF_OOKFIX_FIXEDTHRESH_VALUE				0x06  // Default
+#define RF_OOKFIX_FIXEDTHRESH_VALUE       0x06  // Default
 
 
 // RegAfcFei
-#define RF_AFCFEI_FEI_DONE						    0x40
-#define RF_AFCFEI_FEI_START						    0x20
-#define RF_AFCFEI_AFC_DONE						    0x10
-#define RF_AFCFEI_AFCAUTOCLEAR_ON			  	0x08
-#define RF_AFCFEI_AFCAUTOCLEAR_OFF				0x00  // Default
+#define RF_AFCFEI_FEI_DONE                0x40
+#define RF_AFCFEI_FEI_START               0x20
+#define RF_AFCFEI_AFC_DONE                0x10
+#define RF_AFCFEI_AFCAUTOCLEAR_ON         0x08
+#define RF_AFCFEI_AFCAUTOCLEAR_OFF        0x00  // Default
 
-#define RF_AFCFEI_AFCAUTO_ON					    0x04
-#define RF_AFCFEI_AFCAUTO_OFF					    0x00  // Default
+#define RF_AFCFEI_AFCAUTO_ON              0x04
+#define RF_AFCFEI_AFCAUTO_OFF             0x00  // Default
 
-#define RF_AFCFEI_AFC_CLEAR						    0x02
-#define RF_AFCFEI_AFC_START						    0x01
+#define RF_AFCFEI_AFC_CLEAR               0x02
+#define RF_AFCFEI_AFC_START               0x01
 
 // RegRssiConfig
-#define RF_RSSI_FASTRX_ON						      0x08
-#define RF_RSSI_FASTRX_OFF						    0x00  // Default
-#define RF_RSSI_DONE							        0x02
-#define RF_RSSI_START							        0x01
+#define RF_RSSI_FASTRX_ON                 0x08
+#define RF_RSSI_FASTRX_OFF                0x00  // Default
+#define RF_RSSI_DONE                      0x02
+#define RF_RSSI_START                     0x01
 
 
 // RegDioMapping1
-#define RF_DIOMAPPING1_DIO0_00	  				0x00  // Default
-#define RF_DIOMAPPING1_DIO0_01		  			0x40
-#define RF_DIOMAPPING1_DIO0_10			  		0x80
-#define RF_DIOMAPPING1_DIO0_11				  	0xC0
+#define RF_DIOMAPPING1_DIO0_00            0x00  // Default
+#define RF_DIOMAPPING1_DIO0_01            0x40
+#define RF_DIOMAPPING1_DIO0_10            0x80
+#define RF_DIOMAPPING1_DIO0_11            0xC0
 
-#define RF_DIOMAPPING1_DIO1_00   					0x00  // Default
-#define RF_DIOMAPPING1_DIO1_01		  			0x10
-#define RF_DIOMAPPING1_DIO1_10			  		0x20
-#define RF_DIOMAPPING1_DIO1_11				  	0x30
+#define RF_DIOMAPPING1_DIO1_00            0x00  // Default
+#define RF_DIOMAPPING1_DIO1_01            0x10
+#define RF_DIOMAPPING1_DIO1_10            0x20
+#define RF_DIOMAPPING1_DIO1_11            0x30
 
-#define RF_DIOMAPPING1_DIO2_00	  				0x00  // Default
-#define RF_DIOMAPPING1_DIO2_01		  			0x04
-#define RF_DIOMAPPING1_DIO2_10			  		0x08
-#define RF_DIOMAPPING1_DIO2_11				  	0x0C
+#define RF_DIOMAPPING1_DIO2_00            0x00  // Default
+#define RF_DIOMAPPING1_DIO2_01            0x04
+#define RF_DIOMAPPING1_DIO2_10            0x08
+#define RF_DIOMAPPING1_DIO2_11            0x0C
 
-#define RF_DIOMAPPING1_DIO3_00	  				0x00  // Default
-#define RF_DIOMAPPING1_DIO3_01		  			0x01
-#define RF_DIOMAPPING1_DIO3_10			  		0x02
-#define RF_DIOMAPPING1_DIO3_11				  	0x03
+#define RF_DIOMAPPING1_DIO3_00            0x00  // Default
+#define RF_DIOMAPPING1_DIO3_01            0x01
+#define RF_DIOMAPPING1_DIO3_10            0x02
+#define RF_DIOMAPPING1_DIO3_11            0x03
 
 
 // RegDioMapping2
-#define RF_DIOMAPPING2_DIO4_00	  				0x00  // Default
-#define RF_DIOMAPPING2_DIO4_01		  			0x40
-#define RF_DIOMAPPING2_DIO4_10			  		0x80
-#define RF_DIOMAPPING2_DIO4_11				  	0xC0
+#define RF_DIOMAPPING2_DIO4_00            0x00  // Default
+#define RF_DIOMAPPING2_DIO4_01            0x40
+#define RF_DIOMAPPING2_DIO4_10            0x80
+#define RF_DIOMAPPING2_DIO4_11            0xC0
 
-#define RF_DIOMAPPING2_DIO5_00	  				0x00  // Default
-#define RF_DIOMAPPING2_DIO5_01		  			0x10
-#define RF_DIOMAPPING2_DIO5_10			  		0x20
-#define RF_DIOMAPPING2_DIO5_11				  	0x30
+#define RF_DIOMAPPING2_DIO5_00            0x00  // Default
+#define RF_DIOMAPPING2_DIO5_01            0x10
+#define RF_DIOMAPPING2_DIO5_10            0x20
+#define RF_DIOMAPPING2_DIO5_11            0x30
 
-#define RF_DIOMAPPING2_CLKOUT_32	  			0x00
-#define RF_DIOMAPPING2_CLKOUT_16		  		0x01
-#define RF_DIOMAPPING2_CLKOUT_8				  	0x02
-#define RF_DIOMAPPING2_CLKOUT_4					  0x03
-#define RF_DIOMAPPING2_CLKOUT_2		  			0x04
-#define RF_DIOMAPPING2_CLKOUT_1			  		0x05
-#define RF_DIOMAPPING2_CLKOUT_RC			  	0x06
-#define RF_DIOMAPPING2_CLKOUT_OFF				  0x07  // Default
+#define RF_DIOMAPPING2_CLKOUT_32          0x00
+#define RF_DIOMAPPING2_CLKOUT_16          0x01
+#define RF_DIOMAPPING2_CLKOUT_8           0x02
+#define RF_DIOMAPPING2_CLKOUT_4           0x03
+#define RF_DIOMAPPING2_CLKOUT_2           0x04
+#define RF_DIOMAPPING2_CLKOUT_1           0x05
+#define RF_DIOMAPPING2_CLKOUT_RC          0x06
+#define RF_DIOMAPPING2_CLKOUT_OFF         0x07  // Default
 
 
 // RegIrqFlags1
-#define RF_IRQFLAGS1_MODEREADY					  0x80
-#define RF_IRQFLAGS1_RXREADY					    0x40
-#define RF_IRQFLAGS1_TXREADY					    0x20
-#define RF_IRQFLAGS1_PLLLOCK					    0x10
-#define RF_IRQFLAGS1_RSSI						      0x08
-#define RF_IRQFLAGS1_TIMEOUT					    0x04
-#define RF_IRQFLAGS1_AUTOMODE					    0x02
-#define RF_IRQFLAGS1_SYNCADDRESSMATCH			0x01
+#define RF_IRQFLAGS1_MODEREADY            0x80
+#define RF_IRQFLAGS1_RXREADY              0x40
+#define RF_IRQFLAGS1_TXREADY              0x20
+#define RF_IRQFLAGS1_PLLLOCK              0x10
+#define RF_IRQFLAGS1_RSSI                 0x08
+#define RF_IRQFLAGS1_TIMEOUT              0x04
+#define RF_IRQFLAGS1_AUTOMODE             0x02
+#define RF_IRQFLAGS1_SYNCADDRESSMATCH     0x01
 
 // RegIrqFlags2
-#define RF_IRQFLAGS2_FIFOFULL					    0x80
-#define RF_IRQFLAGS2_FIFONOTEMPTY				  0x40
-#define RF_IRQFLAGS2_FIFOLEVEL					  0x20
-#define RF_IRQFLAGS2_FIFOOVERRUN				  0x10
-#define RF_IRQFLAGS2_PACKETSENT					  0x08
-#define RF_IRQFLAGS2_PAYLOADREADY				  0x04
-#define RF_IRQFLAGS2_CRCOK						    0x02
-#define RF_IRQFLAGS2_LOWBAT						    0x01
+#define RF_IRQFLAGS2_FIFOFULL             0x80
+#define RF_IRQFLAGS2_FIFONOTEMPTY         0x40
+#define RF_IRQFLAGS2_FIFOLEVEL            0x20
+#define RF_IRQFLAGS2_FIFOOVERRUN          0x10
+#define RF_IRQFLAGS2_PACKETSENT           0x08
+#define RF_IRQFLAGS2_PAYLOADREADY         0x04
+#define RF_IRQFLAGS2_CRCOK                0x02
+#define RF_IRQFLAGS2_LOWBAT               0x01
 
 // RegRssiThresh
-#define RF_RSSITHRESH_VALUE						    0xE4  // Default
+#define RF_RSSITHRESH_VALUE               0xE4  // Default
 
 // RegRxTimeout1
-#define RF_RXTIMEOUT1_RXSTART_VALUE				0x00  // Default
+#define RF_RXTIMEOUT1_RXSTART_VALUE       0x00  // Default
 
 // RegRxTimeout2
-#define RF_RXTIMEOUT2_RSSITHRESH_VALUE		0x00  // Default
+#define RF_RXTIMEOUT2_RSSITHRESH_VALUE    0x00  // Default
 
 // RegPreamble
-#define RF_PREAMBLESIZE_MSB_VALUE				  0x00  // Default
-#define RF_PREAMBLESIZE_LSB_VALUE				  0x03  // Default
+#define RF_PREAMBLESIZE_MSB_VALUE         0x00  // Default
+#define RF_PREAMBLESIZE_LSB_VALUE         0x03  // Default
 
 
 // RegSyncConfig
-#define RF_SYNC_ON								0x80  // Default
-#define RF_SYNC_OFF								0x00
+#define RF_SYNC_ON                0x80  // Default
+#define RF_SYNC_OFF               0x00
 
-#define RF_SYNC_FIFOFILL_AUTO			0x00  // Default -- when sync interrupt occurs
-#define RF_SYNC_FIFOFILL_MANUAL		0x40
+#define RF_SYNC_FIFOFILL_AUTO     0x00  // Default -- when sync interrupt occurs
+#define RF_SYNC_FIFOFILL_MANUAL   0x40
 
-#define RF_SYNC_SIZE_1						0x00
-#define RF_SYNC_SIZE_2						0x08
-#define RF_SYNC_SIZE_3						0x10
-#define RF_SYNC_SIZE_4						0x18  // Default
-#define RF_SYNC_SIZE_5						0x20
-#define RF_SYNC_SIZE_6						0x28
-#define RF_SYNC_SIZE_7						0x30
-#define RF_SYNC_SIZE_8						0x38
+#define RF_SYNC_SIZE_1            0x00
+#define RF_SYNC_SIZE_2            0x08
+#define RF_SYNC_SIZE_3            0x10
+#define RF_SYNC_SIZE_4            0x18  // Default
+#define RF_SYNC_SIZE_5            0x20
+#define RF_SYNC_SIZE_6            0x28
+#define RF_SYNC_SIZE_7            0x30
+#define RF_SYNC_SIZE_8            0x38
 
-#define RF_SYNC_TOL_0							0x00  // Default
-#define RF_SYNC_TOL_1							0x01
-#define RF_SYNC_TOL_2							0x02
-#define RF_SYNC_TOL_3							0x03
-#define RF_SYNC_TOL_4							0x04
-#define RF_SYNC_TOL_5							0x05
-#define RF_SYNC_TOL_6							0x06
-#define RF_SYNC_TOL_7							0x07
+#define RF_SYNC_TOL_0             0x00  // Default
+#define RF_SYNC_TOL_1             0x01
+#define RF_SYNC_TOL_2             0x02
+#define RF_SYNC_TOL_3             0x03
+#define RF_SYNC_TOL_4             0x04
+#define RF_SYNC_TOL_5             0x05
+#define RF_SYNC_TOL_6             0x06
+#define RF_SYNC_TOL_7             0x07
 
 
 // RegSyncValue1-8
-#define RF_SYNC_BYTE1_VALUE				0x00  // Default
-#define RF_SYNC_BYTE2_VALUE				0x00  // Default
-#define RF_SYNC_BYTE3_VALUE				0x00  // Default
-#define RF_SYNC_BYTE4_VALUE				0x00  // Default
-#define RF_SYNC_BYTE5_VALUE				0x00  // Default
-#define RF_SYNC_BYTE6_VALUE				0x00  // Default
-#define RF_SYNC_BYTE7_VALUE				0x00  // Default
-#define RF_SYNC_BYTE8_VALUE				0x00  // Default
+#define RF_SYNC_BYTE1_VALUE       0x00  // Default
+#define RF_SYNC_BYTE2_VALUE       0x00  // Default
+#define RF_SYNC_BYTE3_VALUE       0x00  // Default
+#define RF_SYNC_BYTE4_VALUE       0x00  // Default
+#define RF_SYNC_BYTE5_VALUE       0x00  // Default
+#define RF_SYNC_BYTE6_VALUE       0x00  // Default
+#define RF_SYNC_BYTE7_VALUE       0x00  // Default
+#define RF_SYNC_BYTE8_VALUE       0x00  // Default
 
 
 // RegPacketConfig1
-#define RF_PACKET1_FORMAT_FIXED				0x00  // Default
-#define RF_PACKET1_FORMAT_VARIABLE		0x80
+#define RF_PACKET1_FORMAT_FIXED       0x00  // Default
+#define RF_PACKET1_FORMAT_VARIABLE    0x80
 
-#define RF_PACKET1_DCFREE_OFF					0x00  // Default
-#define RF_PACKET1_DCFREE_MANCHESTER	0x20
-#define RF_PACKET1_DCFREE_WHITENING		0x40
+#define RF_PACKET1_DCFREE_OFF         0x00  // Default
+#define RF_PACKET1_DCFREE_MANCHESTER  0x20
+#define RF_PACKET1_DCFREE_WHITENING   0x40
 
-#define RF_PACKET1_CRC_ON						  0x10  // Default
-#define RF_PACKET1_CRC_OFF						0x00
+#define RF_PACKET1_CRC_ON             0x10  // Default
+#define RF_PACKET1_CRC_OFF            0x00
 
-#define RF_PACKET1_CRCAUTOCLEAR_ON		0x00  // Default
-#define RF_PACKET1_CRCAUTOCLEAR_OFF		0x08
+#define RF_PACKET1_CRCAUTOCLEAR_ON    0x00  // Default
+#define RF_PACKET1_CRCAUTOCLEAR_OFF   0x08
 
-#define RF_PACKET1_ADRSFILTERING_OFF			      0x00  // Default
-#define RF_PACKET1_ADRSFILTERING_NODE			      0x02
-#define RF_PACKET1_ADRSFILTERING_NODEBROADCAST	0x04
+#define RF_PACKET1_ADRSFILTERING_OFF            0x00  // Default
+#define RF_PACKET1_ADRSFILTERING_NODE           0x02
+#define RF_PACKET1_ADRSFILTERING_NODEBROADCAST  0x04
 
 
 // RegPayloadLength
-#define RF_PAYLOADLENGTH_VALUE					0x40  // Default
+#define RF_PAYLOADLENGTH_VALUE          0x40  // Default
 
 // RegBroadcastAdrs
-#define RF_BROADCASTADDRESS_VALUE				0x00
+#define RF_BROADCASTADDRESS_VALUE       0x00
 
 
 // RegAutoModes
-#define RF_AUTOMODES_ENTER_OFF					      0x00  // Default
-#define RF_AUTOMODES_ENTER_FIFONOTEMPTY			  0x20
-#define RF_AUTOMODES_ENTER_FIFOLEVEL			    0x40
-#define RF_AUTOMODES_ENTER_CRCOK				      0x60
-#define RF_AUTOMODES_ENTER_PAYLOADREADY			  0x80
-#define RF_AUTOMODES_ENTER_SYNCADRSMATCH		  0xA0
-#define RF_AUTOMODES_ENTER_PACKETSENT			    0xC0
-#define RF_AUTOMODES_ENTER_FIFOEMPTY			    0xE0
+#define RF_AUTOMODES_ENTER_OFF                0x00  // Default
+#define RF_AUTOMODES_ENTER_FIFONOTEMPTY       0x20
+#define RF_AUTOMODES_ENTER_FIFOLEVEL          0x40
+#define RF_AUTOMODES_ENTER_CRCOK              0x60
+#define RF_AUTOMODES_ENTER_PAYLOADREADY       0x80
+#define RF_AUTOMODES_ENTER_SYNCADRSMATCH      0xA0
+#define RF_AUTOMODES_ENTER_PACKETSENT         0xC0
+#define RF_AUTOMODES_ENTER_FIFOEMPTY          0xE0
 
-#define RF_AUTOMODES_EXIT_OFF					        0x00  // Default
-#define RF_AUTOMODES_EXIT_FIFOEMPTY		  		  0x04
-#define RF_AUTOMODES_EXIT_FIFOLEVEL	  			  0x08
-#define RF_AUTOMODES_EXIT_CRCOK					      0x0C
-#define RF_AUTOMODES_EXIT_PAYLOADREADY		  	0x10
-#define RF_AUTOMODES_EXIT_SYNCADRSMATCH			  0x14
-#define RF_AUTOMODES_EXIT_PACKETSENT		  	  0x18
-#define RF_AUTOMODES_EXIT_RXTIMEOUT				    0x1C
+#define RF_AUTOMODES_EXIT_OFF                 0x00  // Default
+#define RF_AUTOMODES_EXIT_FIFOEMPTY           0x04
+#define RF_AUTOMODES_EXIT_FIFOLEVEL           0x08
+#define RF_AUTOMODES_EXIT_CRCOK               0x0C
+#define RF_AUTOMODES_EXIT_PAYLOADREADY        0x10
+#define RF_AUTOMODES_EXIT_SYNCADRSMATCH       0x14
+#define RF_AUTOMODES_EXIT_PACKETSENT          0x18
+#define RF_AUTOMODES_EXIT_RXTIMEOUT           0x1C
 
-#define RF_AUTOMODES_INTERMEDIATE_SLEEP			  0x00  // Default
-#define RF_AUTOMODES_INTERMEDIATE_STANDBY		  0x01
-#define RF_AUTOMODES_INTERMEDIATE_RECEIVER		0x02
-#define RF_AUTOMODES_INTERMEDIATE_TRANSMITTER	0x03
+#define RF_AUTOMODES_INTERMEDIATE_SLEEP       0x00  // Default
+#define RF_AUTOMODES_INTERMEDIATE_STANDBY     0x01
+#define RF_AUTOMODES_INTERMEDIATE_RECEIVER    0x02
+#define RF_AUTOMODES_INTERMEDIATE_TRANSMITTER 0x03
 
 
 // RegFifoThresh
-#define RF_FIFOTHRESH_TXSTART_FIFOTHRESH		  0x00
-#define RF_FIFOTHRESH_TXSTART_FIFONOTEMPTY		0x80  // Default
+#define RF_FIFOTHRESH_TXSTART_FIFOTHRESH      0x00
+#define RF_FIFOTHRESH_TXSTART_FIFONOTEMPTY    0x80  // Default
 
-#define RF_FIFOTHRESH_VALUE						        0x0F  // Default
+#define RF_FIFOTHRESH_VALUE                   0x0F  // Default
 
 
 // RegPacketConfig2
-#define RF_PACKET2_RXRESTARTDELAY_1BIT			  0x00  // Default
-#define RF_PACKET2_RXRESTARTDELAY_2BITS			  0x10
-#define RF_PACKET2_RXRESTARTDELAY_4BITS	  		0x20
-#define RF_PACKET2_RXRESTARTDELAY_8BITS		  	0x30
-#define RF_PACKET2_RXRESTARTDELAY_16BITS		  0x40
-#define RF_PACKET2_RXRESTARTDELAY_32BITS  		0x50
-#define RF_PACKET2_RXRESTARTDELAY_64BITS	  	0x60
-#define RF_PACKET2_RXRESTARTDELAY_128BITS		  0x70
-#define RF_PACKET2_RXRESTARTDELAY_256BITS 		0x80
-#define RF_PACKET2_RXRESTARTDELAY_512BITS	  	0x90
-#define RF_PACKET2_RXRESTARTDELAY_1024BITS		0xA0
-#define RF_PACKET2_RXRESTARTDELAY_2048BITS		0xB0
-#define RF_PACKET2_RXRESTARTDELAY_NONE			  0xC0
-#define RF_PACKET2_RXRESTART					        0x04
+#define RF_PACKET2_RXRESTARTDELAY_1BIT        0x00  // Default
+#define RF_PACKET2_RXRESTARTDELAY_2BITS       0x10
+#define RF_PACKET2_RXRESTARTDELAY_4BITS       0x20
+#define RF_PACKET2_RXRESTARTDELAY_8BITS       0x30
+#define RF_PACKET2_RXRESTARTDELAY_16BITS      0x40
+#define RF_PACKET2_RXRESTARTDELAY_32BITS      0x50
+#define RF_PACKET2_RXRESTARTDELAY_64BITS      0x60
+#define RF_PACKET2_RXRESTARTDELAY_128BITS     0x70
+#define RF_PACKET2_RXRESTARTDELAY_256BITS     0x80
+#define RF_PACKET2_RXRESTARTDELAY_512BITS     0x90
+#define RF_PACKET2_RXRESTARTDELAY_1024BITS    0xA0
+#define RF_PACKET2_RXRESTARTDELAY_2048BITS    0xB0
+#define RF_PACKET2_RXRESTARTDELAY_NONE        0xC0
+#define RF_PACKET2_RXRESTART                  0x04
 
-#define RF_PACKET2_AUTORXRESTART_ON				    0x02  // Default
-#define RF_PACKET2_AUTORXRESTART_OFF			    0x00
+#define RF_PACKET2_AUTORXRESTART_ON           0x02  // Default
+#define RF_PACKET2_AUTORXRESTART_OFF          0x00
 
-#define RF_PACKET2_AES_ON						          0x01
-#define RF_PACKET2_AES_OFF						        0x00  // Default
+#define RF_PACKET2_AES_ON                     0x01
+#define RF_PACKET2_AES_OFF                    0x00  // Default
 
 
 // RegAesKey1-16
-#define RF_AESKEY1_VALUE						0x00  // Default
-#define RF_AESKEY2_VALUE						0x00  // Default
-#define RF_AESKEY3_VALUE						0x00  // Default
-#define RF_AESKEY4_VALUE						0x00  // Default
-#define RF_AESKEY5_VALUE						0x00  // Default
-#define RF_AESKEY6_VALUE						0x00  // Default
-#define RF_AESKEY7_VALUE						0x00  // Default
-#define RF_AESKEY8_VALUE						0x00  // Default
-#define RF_AESKEY9_VALUE						0x00  // Default
-#define RF_AESKEY10_VALUE						0x00  // Default
-#define RF_AESKEY11_VALUE						0x00  // Default
-#define RF_AESKEY12_VALUE						0x00  // Default
-#define RF_AESKEY13_VALUE						0x00  // Default
-#define RF_AESKEY14_VALUE						0x00  // Default
-#define RF_AESKEY15_VALUE						0x00  // Default
-#define RF_AESKEY16_VALUE						0x00  // Default
+#define RF_AESKEY1_VALUE            0x00  // Default
+#define RF_AESKEY2_VALUE            0x00  // Default
+#define RF_AESKEY3_VALUE            0x00  // Default
+#define RF_AESKEY4_VALUE            0x00  // Default
+#define RF_AESKEY5_VALUE            0x00  // Default
+#define RF_AESKEY6_VALUE            0x00  // Default
+#define RF_AESKEY7_VALUE            0x00  // Default
+#define RF_AESKEY8_VALUE            0x00  // Default
+#define RF_AESKEY9_VALUE            0x00  // Default
+#define RF_AESKEY10_VALUE           0x00  // Default
+#define RF_AESKEY11_VALUE           0x00  // Default
+#define RF_AESKEY12_VALUE           0x00  // Default
+#define RF_AESKEY13_VALUE           0x00  // Default
+#define RF_AESKEY14_VALUE           0x00  // Default
+#define RF_AESKEY15_VALUE           0x00  // Default
+#define RF_AESKEY16_VALUE           0x00  // Default
 
 
 // RegTemp1
-#define RF_TEMP1_MEAS_START					0x08
-#define RF_TEMP1_MEAS_RUNNING				0x04
-#define RF_TEMP1_ADCLOWPOWER_ON			0x01  // Default
-#define RF_TEMP1_ADCLOWPOWER_OFF		0x00
+#define RF_TEMP1_MEAS_START         0x08
+#define RF_TEMP1_MEAS_RUNNING       0x04
+#define RF_TEMP1_ADCLOWPOWER_ON     0x01  // Default
+#define RF_TEMP1_ADCLOWPOWER_OFF    0x00
 
 // RegTestDagc 0x6F: demodulator config and IO mode config
 #define RF_DAGC_NORMAL              0x00  // Reset value


### PR DESCRIPTION
Use `git diff --ignore-space-change` to verify.
The code should now look the same in many kinds of editors.