### PR TITLE
Moving Blink def so it compiles on PlatformIO

### DIFF
--- a/Examples/Node/Node.ino
+++ b/Examples/Node/Node.ino
@@ -55,7 +55,7 @@ void setup() {
 #endif
   radio.encrypt(ENCRYPTKEY);
   //radio.setFrequency(919000000); //set frequency to some custom frequency
-  
+
 //Auto Transmission Control - dials down transmit power to save battery (-100 is the noise floor, -90 is still pretty good)
 //For indoor nodes that are pretty static and at pretty stable temperatures (like a MotionMote) -90dBm is quite safe
 //For more variable nodes that can expect to move or experience larger temp drifts a lower margin like -70 to -80 would probably be better
@@ -63,11 +63,11 @@ void setup() {
 #ifdef ENABLE_ATC
   radio.enableAutoPower(-70);
 #endif
-  
+
   char buff[50];
   sprintf(buff, "\nTransmitting at %d Mhz...", FREQUENCY==RF69_433MHZ ? 433 : FREQUENCY==RF69_868MHZ ? 868 : 915);
   Serial.println(buff);
-  
+
   if (flash.initialize())
   {
     Serial.print("SPI Flash Init OK ... UniqueID (MAC): ");
@@ -81,10 +81,18 @@ void setup() {
   }
   else
     Serial.println("SPI Flash MEM not found (is chip soldered?)...");
-    
+
 #ifdef ENABLE_ATC
   Serial.println("RFM69_ATC Enabled (Auto Transmission Control)\n");
 #endif
+}
+
+void Blink(byte PIN, int DELAY_MS)
+{
+  pinMode(PIN, OUTPUT);
+  digitalWrite(PIN,HIGH);
+  delay(DELAY_MS);
+  digitalWrite(PIN,LOW);
 }
 
 long lastPeriod = 0;
@@ -158,7 +166,7 @@ void loop() {
   if (currPeriod != lastPeriod)
   {
     lastPeriod=currPeriod;
-    
+
     //send FLASH id
     if(sendSize==0)
     {
@@ -176,7 +184,7 @@ void loop() {
       Serial.print("]: ");
       for(byte i = 0; i < sendSize; i++)
         Serial.print((char)payload[i]);
-  
+
       if (radio.sendWithRetry(GATEWAYID, payload, sendSize))
        Serial.print(" ok!");
       else Serial.print(" nothing...");
@@ -185,12 +193,4 @@ void loop() {
     Serial.println();
     Blink(LED,3);
   }
-}
-
-void Blink(byte PIN, int DELAY_MS)
-{
-  pinMode(PIN, OUTPUT);
-  digitalWrite(PIN,HIGH);
-  delay(DELAY_MS);
-  digitalWrite(PIN,LOW);
 }


### PR DESCRIPTION
Without this, trying to compile with PlatformIO yields (on OSX El Capitan but I'm seeing the same error trying to compile on an Pi2). I checked and this also affects other examples:

```
✔ ~/moteino
02:27 $ platformio run
[Mon Mar  7 02:27:50 2016] Processing moteino (platform: atmelavr, board: moteino, framework: arduino)
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Installing toolchain-atmelavr package:
Already installed
Installing tool-scons package:
Downloading  [####################################]  100%
Unpacking  [####################################]  100%
Installing framework-arduinoavr package:
Downloading  [####################################]  100%
Unpacking  [####################################]  100%
avr-g++ -o .pioenvs/moteino/src/main.o -c -fno-exceptions -fno-threadsafe-statics -std=gnu++11 -g -Os -Wall -ffunction-sections -fdata-sections -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO_ARCH_AVR -DAVR_MOTEINO -DARDUINO=10607 -DPLATFORMIO=020804 -I.pioenvs/moteino/FrameworkArduino -I.pioenvs/moteino/FrameworkArduinoVariant -I.pioenvs/moteino/SPI src/main.cpp
avr-ar rcs .pioenvs/moteino/libFrameworkArduinoVariant.a
avr-ranlib .pioenvs/moteino/libFrameworkArduinoVariant.a
src/main.cpp:7:78: fatal error: RFM69.h: No such file or directory
#include <RFM69.h>    //get it here: https://www.github.com/lowpowerlab/rfm69
^
compilation terminated.
avr-g++ -o .pioenvs/moteino/FrameworkArduino/CDC.o -c -fno-exceptions -fno-threadsafe-statics -std=gnu++11 -g -Os -Wall -ffunction-sections -fdata-sections -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO_ARCH_AVR -DAVR_MOTEINO -DARDUINO=10607 -I.pioenvs/moteino/FrameworkArduino -I.pioenvs/moteino/FrameworkArduinoVariant .pioenvs/moteino/FrameworkArduino/CDC.cpp
avr-g++ -o .pioenvs/moteino/FrameworkArduino/HardwareSerial.o -c -fno-exceptions -fno-threadsafe-statics -std=gnu++11 -g -Os -Wall -ffunction-sections -fdata-sections -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO_ARCH_AVR -DAVR_MOTEINO -DARDUINO=10607 -I.pioenvs/moteino/FrameworkArduino -I.pioenvs/moteino/FrameworkArduinoVariant .pioenvs/moteino/FrameworkArduino/HardwareSerial.cpp
avr-g++ -o .pioenvs/moteino/FrameworkArduino/HardwareSerial0.o -c -fno-exceptions -fno-threadsafe-statics -std=gnu++11 -g -Os -Wall -ffunction-sections -fdata-sections -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO_ARCH_AVR -DAVR_MOTEINO -DARDUINO=10607 -I.pioenvs/moteino/FrameworkArduino -I.pioenvs/moteino/FrameworkArduinoVariant .pioenvs/moteino/FrameworkArduino/HardwareSerial0.cpp
avr-g++ -o .pioenvs/moteino/FrameworkArduino/HardwareSerial1.o -c -fno-exceptions -fno-threadsafe-statics -std=gnu++11 -g -Os -Wall -ffunction-sections -fdata-sections -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO_ARCH_AVR -DAVR_MOTEINO -DARDUINO=10607 -I.pioenvs/moteino/FrameworkArduino -I.pioenvs/moteino/FrameworkArduinoVariant .pioenvs/moteino/FrameworkArduino/HardwareSerial1.cpp
avr-g++ -o .pioenvs/moteino/FrameworkArduino/HardwareSerial2.o -c -fno-exceptions -fno-threadsafe-statics -std=gnu++11 -g -Os -Wall -ffunction-sections -fdata-sections -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO_ARCH_AVR -DAVR_MOTEINO -DARDUINO=10607 -I.pioenvs/moteino/FrameworkArduino -I.pioenvs/moteino/FrameworkArduinoVariant .pioenvs/moteino/FrameworkArduino/HardwareSerial2.cpp
scons: *** [.pioenvs/moteino/src/main.o] Error 1
avr-g++ -o .pioenvs/moteino/FrameworkArduino/HardwareSerial3.o -c -fno-exceptions -fno-threadsafe-statics -std=gnu++11 -g -Os -Wall -ffunction-sections -fdata-sections -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO_ARCH_AVR -DAVR_MOTEINO -DARDUINO=10607 -I.pioenvs/moteino/FrameworkArduino -I.pioenvs/moteino/FrameworkArduinoVariant .pioenvs/moteino/FrameworkArduino/HardwareSerial3.cpp
========================================================================== [ ERROR ] Took 5.88 seconds ==========================================================================
```


With this, it works:

```
✔ ~/moteino
02:28 $ platformio run -t upload
[Mon Mar  7 02:29:12 2016] Processing moteino (platform: atmelavr, board: moteino, framework: arduino)
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Installing toolchain-atmelavr package:
Already installed
Installing tool-avrdude package:
Downloading  [####################################]  100%
Unpacking  [####################################]  100%
Installing tool-scons package:
Already installed
Installing framework-arduinoavr package:
Already installed
BeforeUpload(["upload"], [".pioenvs/moteino/firmware.hex"])
Auto-detected UPLOAD_PORT/DISK: /dev/cu.usbserial-DA01IH0H
"/Users/spetrow/.platformio/packages/tool-avrdude/avrdude" -v -p atmega328p -C "/Users/spetrow/.platformio/packages/tool-avrdude/avrdude.conf" -c arduino -b 115200 -P /dev/cu.usbserial-DA01IH0H -D -U flash:w:.pioenvs/moteino/firmware.hex:i

avrdude: Version 6.0.1, compiled on Dec 16 2013 at 17:26:24
Copyright (c) 2000-2005 Brian Dean, http://www.bdmicro.com/
Copyright (c) 2007-2009 Joerg Wunsch

System wide configuration file is "/Users/spetrow/.platformio/packages/tool-avrdude/avrdude.conf"
User configuration file is "/Users/spetrow/.avrduderc"
User configuration file does not exist or is not a regular file, skipping

Using Port                    : /dev/cu.usbserial-DA01IH0H
Using Programmer              : arduino
Overriding Baud Rate          : 115200
AVR Part                      : ATmega328P
Chip Erase delay              : 9000 us
PAGEL                         : PD7
BS2                           : PC2
RESET disposition             : dedicated
RETRY pulse                   : SCK
serial program mode           : yes
parallel program mode         : yes
Timeout                       : 200
StabDelay                     : 100
CmdexeDelay                   : 25
SyncLoops                     : 32
ByteDelay                     : 0
PollIndex                     : 3
PollValue                     : 0x53
Memory Detail                 :

Block Poll               Page                       Polled
Memory Type Mode Delay Size  Indx Paged  Size   Size #Pages MinW  MaxW   ReadBack
----------- ---- ----- ----- ---- ------ ------ ---- ------ ----- ----- ---------
eeprom        65    20     4    0 no       1024    4      0  3600  3600 0xff 0xff
flash         65     6   128    0 yes     32768  128    256  4500  4500 0xff 0xff
lfuse          0     0     0    0 no          1    0      0  4500  4500 0x00 0x00
hfuse          0     0     0    0 no          1    0      0  4500  4500 0x00 0x00
efuse          0     0     0    0 no          1    0      0  4500  4500 0x00 0x00
lock           0     0     0    0 no          1    0      0  4500  4500 0x00 0x00
calibration    0     0     0    0 no          1    0      0     0     0 0x00 0x00
signature      0     0     0    0 no          3    0      0     0     0 0x00 0x00

Programmer Type : Arduino
Description     : Arduino
Hardware Version: 3
Firmware Version: 5.0
Vtarget         : 0.3 V
Varef           : 0.3 V
Oscillator      : 28.800 kHz
SCK period      : 3.3 us

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.00s

avrdude: Device signature = 0x1e950f
avrdude: safemode: lfuse reads as 0
avrdude: safemode: hfuse reads as 0
avrdude: safemode: efuse reads as 0
avrdude: reading input file ".pioenvs/moteino/firmware.hex"
avrdude: writing flash (10060 bytes):

Writing | ################################################## | 100% 3.80s

avrdude: 10060 bytes of flash written
avrdude: verifying flash memory against .pioenvs/moteino/firmware.hex:
avrdude: load data flash data from input file .pioenvs/moteino/firmware.hex:
avrdude: input file .pioenvs/moteino/firmware.hex contains 10060 bytes
avrdude: reading on-chip flash data:

Reading | ################################################## | 100% 3.40s

avrdude: verifying ...
avrdude: 10060 bytes of flash verified

avrdude: safemode: lfuse reads as 0
avrdude: safemode: hfuse reads as 0
avrdude: safemode: efuse reads as 0
avrdude: safemode: Fuses OK (H:00, E:00, L:00)

avrdude done.  Thank you.

========================================================================== [SUCCESS] Took 14.85 seconds ==========================================================================
```