### PR TITLE
Declare RFM69 interrupt with SPI.usingInterrupt()

### DIFF
--- a/RFM69.cpp
+++ b/RFM69.cpp
@@ -91,6 +91,9 @@ bool RFM69::initialize(uint8_t freqBand, uint8_t nodeID, uint8_t networkID)
   digitalWrite(_slaveSelectPin, HIGH);
   pinMode(_slaveSelectPin, OUTPUT);
   SPI.begin();
+#ifdef SPI_HAS_TRANSACTION
+  SPI.usingInterrupt(_interruptNum);
+#endif
   unsigned long start = millis();
   uint8_t timeout = 50;
   do writeReg(REG_SYNCVALUE1, 0xAA); while (readReg(REG_SYNCVALUE1) != 0xaa && millis()-start < timeout);


### PR DESCRIPTION
This interrupt is then masked during SPI transactions of other
code/libraries that use SPI transactions, to prevent the RFM69
interrupt handler (which does SPI transfers) preempting other SPI
transfers.