### PR TITLE
Revert "Declare RFM69 interrupt with SPI.usingInterrupt()"

### DIFF
--- a/RFM69.cpp
+++ b/RFM69.cpp
@@ -91,9 +91,6 @@ bool RFM69::initialize(uint8_t freqBand, uint8_t nodeID, uint8_t networkID)
   digitalWrite(_slaveSelectPin, HIGH);
   pinMode(_slaveSelectPin, OUTPUT);
   SPI.begin();
-#ifdef SPI_HAS_TRANSACTION
-  SPI.usingInterrupt(_interruptNum);
-#endif
   unsigned long start = millis();
   uint8_t timeout = 50;
   do writeReg(REG_SYNCVALUE1, 0xAA); while (readReg(REG_SYNCVALUE1) != 0xaa && millis()-start < timeout);


### PR DESCRIPTION
Reverts LowPowerLab/RFM69#46
Causing freezes on 1.6.9 (although none on 1.0.6).