### PR TITLE
Handle interrupt outside actual ISR

### DIFF
--- a/RFM69.h
+++ b/RFM69.h
@@ -124,9 +124,9 @@ class RFM69 {
 
   protected:
     static void isr0();
-    void virtual interruptHandler();
+	void interruptHandler();
     virtual void interruptHook(uint8_t CTLbyte) {};
-    static volatile bool _inISR;
+    static volatile bool _haveData;
     virtual void sendFrame(uint8_t toAddress, const void* buffer, uint8_t size, bool requestACK=false, bool sendACK=false);
 
     static RFM69* selfPointer;
@@ -147,7 +147,6 @@ class RFM69 {
     virtual void setHighPowerRegs(bool onOff);
     virtual void select();
     virtual void unselect();
-    inline void maybeInterrupts();
 };
 
 #endif


### PR DESCRIPTION
Handling an interrupt from the RFM69 inside an actual ISR given the
complexity of the handler appears to conflict with I2C devices, blocking
the Arduino indefinitely after a few seconds of concurrent use. In
general, complex ISRs are to be avoided.

Discussion on the issue over directly merging this is acceptable too.