### PR TITLE
Add ATtiny support

### DIFF
--- a/RFM69.cpp
+++ b/RFM69.cpp
@@ -25,7 +25,7 @@
 // **********************************************************************************
 #include <RFM69.h>
 #include <RFM69registers.h>
-#include <SPI.h>
+#include <RFM69_SPI.h>
 
 volatile uint8_t RFM69::DATA[RF69_MAX_DATA_LEN];
 volatile uint8_t RFM69::_mode;        // current transceiver state
@@ -490,6 +490,7 @@ void RFM69::setCS(uint8_t newSPISlaveSelect) {
   pinMode(_slaveSelectPin, OUTPUT);
 }
 
+#if defined(SERIAL_DEBUG)
 //for debugging
 #define REGISTER_DETAIL 0
 #if REGISTER_DETAIL
@@ -797,6 +798,8 @@ void RFM69::readAllRegsCompact() {
     Serial.print(" ");
   }
 }
+
+#endif // SERIAL_DEBUG
 
 uint8_t RFM69::readTemperature(uint8_t calFactor) // returns centigrade
 {

--- a/RFM69.h
+++ b/RFM69.h
@@ -28,7 +28,11 @@
 #include <Arduino.h>            // assumes Arduino IDE v1.0 or greater
 
 #define RF69_MAX_DATA_LEN       61 // to take advantage of the built in AES/CRC we want to limit the frame size to the internal FIFO size (66 bytes - 3 bytes overhead - 2 bytes crc)
-#define RF69_SPI_CS             SS // SS is the SPI slave select pin, for instance D10 on ATmega328
+#if defined(__AVR_ATtiny85__)
+  #define RF69_SPI_CS           3
+#else
+  #define RF69_SPI_CS           SS // SS is the SPI slave select pin, for instance D10 on ATmega328
+#endif
 
 // INT0 on AVRs should be connected to RFM69's DIO0 (ex on ATmega328 it's D2, on ATmega644/1284 it's D2)
 #if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__) || defined(__AVR_ATmega88) || defined(__AVR_ATmega8__) || defined(__AVR_ATmega88__)
@@ -43,6 +47,9 @@
 #elif defined(__arm__)//Use pin 10 or any pin you want
   #define RF69_IRQ_PIN          10
   #define RF69_IRQ_NUM          10
+#elif defined(__AVR_ATtiny85__)
+  #define RF69_IRQ_PIN          4
+  #define RF69_IRQ_NUM          4        
 #else 
   #define RF69_IRQ_PIN          2
   #define RF69_IRQ_NUM          0  
@@ -72,6 +79,11 @@
 // TWS: define CTLbyte bits
 #define RFM69_CTL_SENDACK   0x80
 #define RFM69_CTL_REQACK    0x40
+
+#if !defined(__AVR_ATtiny85__)
+  #define SERIAL_DEBUG
+#endif
+
 
 class RFM69 {
   public:

--- a/RFM69_ATC.cpp
+++ b/RFM69_ATC.cpp
@@ -28,7 +28,7 @@
 #include <RFM69_ATC.h>
 #include <RFM69.h>   // include the RFM69 library files as well
 #include <RFM69registers.h>
-#include <SPI.h>
+#include <RFM69_SPI.h>
 
 volatile uint8_t RFM69_ATC::ACK_RSSI_REQUESTED;  // new type of flag on ACK_REQUEST
 

--- a/RFM69_OTA.cpp
+++ b/RFM69_OTA.cpp
@@ -30,6 +30,8 @@
 // Please maintain this license information along with authorship
 // and copyright notices in any redistribution of this code
 // **********************************************************************************
+#if !defined(__AVR_ATtiny85__)
+
 #include <RFM69_OTA.h>
 #include <RFM69registers.h>
 #include <avr/wdt.h>
@@ -523,3 +525,5 @@ void resetUsingWatchdog(uint8_t DEBUG)
   wdt_enable(WDTO_15MS);
   while(1) if (DEBUG) Serial.print(F("."));
 }
+
+#endif

--- a/RFM69_OTA.h
+++ b/RFM69_OTA.h
@@ -32,6 +32,9 @@
 // **********************************************************************************
 #ifndef RFM69_OTA_H
 #define RFM69_OTA_H
+
+#if !defined(__AVR_ATtiny85__)
+
 #ifdef __AVR_ATmega1284P__
   #define LED           15 // Moteino MEGAs have LEDs on D15
 #else
@@ -76,4 +79,5 @@ uint8_t BYTEfromHEX(char MSB, char LSB);
 uint8_t readSerialLine(char* input, char endOfLineChar=10, uint8_t maxLength=115, uint16_t timeout=1000);
 void PrintHex83(uint8_t* data, uint8_t length);
 
+#endif
 #endif

--- a/RFM69_SPI.h
+++ b/RFM69_SPI.h
@@ -1,0 +1,100 @@
+#ifndef _RFM69_SPI_H
+#define _RFM69_SPI_H
+
+// Special SPI definition to support ATtiny microcontrollers
+#if defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny84__) || defined(__AVR_ATtiny85__)
+
+#include <util/atomic.h>
+
+//USI ports and pins
+#if defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__)
+#define SPI_DDR_PORT DDRA
+#define USCK_DD_PIN DDA4
+#define DO_DD_PIN DDA5
+#define DI_DD_PIN DDA6
+#elif defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__)
+#define SPI_DDR_PORT DDRB
+#define USCK_DD_PIN DDB2
+#define DO_DD_PIN DDB1
+#define DI_DD_PIN DDB0
+#endif
+
+#define SPI_CLOCK_DIV4 0x00
+#define SPI_CLOCK_DIV16 0x01
+#define SPI_CLOCK_DIV64 0x02
+#define SPI_CLOCK_DIV128 0x03
+#define SPI_CLOCK_DIV2 0x04
+#define SPI_CLOCK_DIV8 0x05
+#define SPI_CLOCK_DIV32 0x06
+
+#define SPI_MODE0 0x00
+#define SPI_MODE1 0x04
+#define SPI_MODE2 0x08
+#define SPI_MODE3 0x0C
+
+
+class ATtinySPI
+{
+  /*----------------------------------------------------------------------*
+   * The ATtinySPI class was derived from tinySPI by Jack Christensen and *
+   * is licensed under CC BY-SA 3.0. Changes were made to the original    *
+   * work which can be found at https://github.com/JChristensen/tinySPI   *
+   *                                                                      *
+   * CC BY-SA:                                                            *
+   * This work is licensed under the Creative Commons Attribution-        *
+   * ShareAlike 3.0 Unported License. To view a copy of this license,     *
+   * visit http://creativecommons.org/licenses/by-sa/3.0/                 *
+   *----------------------------------------------------------------------*/
+    public:
+        static void begin(void)
+        {
+          USICR &= ~(_BV(USISIE) | _BV(USIOIE) | _BV(USIWM1));
+          USICR |= _BV(USIWM0) | _BV(USICS1) | _BV(USICLK);
+          SPI_DDR_PORT |= _BV(USCK_DD_PIN);   //set the USCK pin as output
+          SPI_DDR_PORT |= _BV(DO_DD_PIN);     //set the DO pin as output
+          SPI_DDR_PORT &= ~_BV(DI_DD_PIN);    //set the DI pin as input
+        }
+
+        inline static uint8_t transfer(uint8_t data)
+        {
+          USIDR = data;
+          USISR = _BV(USIOIF);                //clear counter and counter overflow interrupt flag
+          ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { //ensure a consistent clock period
+              while ( !(USISR & _BV(USIOIF)) ) USICR |= _BV(USITC);
+          }
+          return USIDR;
+        }
+
+        static void end(void)
+        {
+          USICR &= ~(_BV(USIWM1) | _BV(USIWM0));
+        }
+
+        // The following functions aren't supported but exist here for backward
+        // compatibility with the RFM69 library. They are not necessary on the 
+        // ATtiny devices.
+        inline static void setBitOrder(uint8_t)
+        {
+          __asm__("nop\n\t");
+        }
+
+        inline static void setDataMode(uint8_t)
+        {
+          __asm__("nop\n\t");
+        }
+
+        inline static void setClockDivider(uint8_t)
+        {
+          __asm__("nop\n\t");
+        }
+};
+
+extern ATtinySPI SPI;
+
+#else
+  // For all other devices use the standard SPI library
+  #include <SPI.h>
+
+#endif // ATtiny device defines
+
+#endif // _RFM69_SPI_H


### PR DESCRIPTION
This PR adds support for the ATtiny85 chip found in the Adafruit Trinket. Because the ATtiny does not support the standard serial library a new define was added to exclude serial debug logging only when compiling for the ATtiny85.