### PR TITLE
Short csma acks

### DIFF
--- a/RFM69.cpp
+++ b/RFM69.cpp
@@ -264,7 +264,7 @@ void RFM69::sendACK(const void* buffer, uint8_t bufferSize) {
   int16_t _RSSI = RSSI; // save payload received RSSI value
   writeReg(REG_PACKETCONFIG2, (readReg(REG_PACKETCONFIG2) & 0xFB) | RF_PACKET2_RXRESTART); // avoid RX deadlocks
   uint32_t now = millis();
-  while (!canSend() && millis() - now < RF69_CSMA_LIMIT_MS) receiveDone();
+  while (!canSend() && millis() - now < RF69_CSMA_LIMIT_ACK_MS) receiveDone();
   SENDERID = sender;    // TWS: Restore SenderID after it gets wiped out by receiveDone()
   sendFrame(sender, buffer, bufferSize, false, true);
   RSSI = _RSSI; // restore payload RSSI

--- a/RFM69.cpp
+++ b/RFM69.cpp
@@ -5,19 +5,19 @@
 // **********************************************************************************
 // License
 // **********************************************************************************
-// This program is free software; you can redistribute it 
-// and/or modify it under the terms of the GNU General    
-// Public License as published by the Free Software       
-// Foundation; either version 3 of the License, or        
-// (at your option) any later version.                    
-//                                                        
-// This program is distributed in the hope that it will   
-// be useful, but WITHOUT ANY WARRANTY; without even the  
-// implied warranty of MERCHANTABILITY or FITNESS FOR A   
-// PARTICULAR PURPOSE. See the GNU General Public        
-// License for more details.                              
-//                                                        
-// Licence can be viewed at                               
+// This program is free software; you can redistribute it
+// and/or modify it under the terms of the GNU General
+// Public License as published by the Free Software
+// Foundation; either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will
+// be useful, but WITHOUT ANY WARRANTY; without even the
+// implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU General Public
+// License for more details.
+//
+// Licence can be viewed at
 // http://www.gnu.org/licenses/gpl-3.0.txt
 //
 // Please maintain this license information along with authorship
@@ -334,7 +334,7 @@ void RFM69::interruptHandler() {
 
     ACK_RECEIVED = CTLbyte & RFM69_CTL_SENDACK; // extract ACK-received flag
     ACK_REQUESTED = CTLbyte & RFM69_CTL_REQACK; // extract ACK-requested flag
-    
+
     interruptHook(CTLbyte);     // TWS: hook to derived class interrupt function
 
     for (uint8_t i = 0; i < DATALEN; i++)
@@ -483,7 +483,7 @@ void RFM69::setHighPowerRegs(bool onOff) {
   writeReg(REG_TESTPA2, onOff ? 0x7C : 0x70);
 }
 
-// set the slave select (CS) pin 
+// set the slave select (CS) pin
 void RFM69::setCS(uint8_t newSPISlaveSelect) {
   _slaveSelectPin = newSPISlaveSelect;
   digitalWrite(_slaveSelectPin, HIGH);
@@ -509,7 +509,7 @@ void RFM69::readAllRegs()
 {
   uint8_t regVal;
 
-#if REGISTER_DETAIL 
+#if REGISTER_DETAIL
   int capVal;
 
   //... State Variables for intelligent decoding
@@ -518,7 +518,7 @@ void RFM69::readAllRegs()
   int freqDev = 0;
   long freqCenter = 0;
 #endif
-  
+
   Serial.println("Address - HEX - BIN");
   for (uint8_t regAddr = 1; regAddr <= 0x4F; regAddr++)
   {
@@ -533,8 +533,8 @@ void RFM69::readAllRegs()
     Serial.print(" - ");
     Serial.println(regVal,BIN);
 
-#if REGISTER_DETAIL 
-    switch ( regAddr ) 
+#if REGISTER_DETAIL
+    switch ( regAddr )
     {
         case 0x1 : {
             SerialPrint ( "Controls the automatic Sequencer ( see section 4.2 )\nSequencerOff : " );
@@ -543,19 +543,19 @@ void RFM69::readAllRegs()
             } else {
                 SerialPrint ( "0 -> Operating mode as selected with Mode bits in RegOpMode is automatically reached with the Sequencer\n" );
             }
-            
+
             SerialPrint( "\nEnables Listen mode, should be enabled whilst in Standby mode:\nListenOn : " );
             if ( 0x40 & regVal ) {
                 SerialPrint ( "1 -> On\n" );
             } else {
                 SerialPrint ( "0 -> Off ( see section 4.3)\n" );
             }
-            
+
             SerialPrint( "\nAborts Listen mode when set together with ListenOn=0 See section 4.3.4 for details (Always reads 0.)\n" );
             if ( 0x20 & regVal ) {
                 SerialPrint ( "ERROR - ListenAbort should NEVER return 1 this is a write only register\n" );
             }
-            
+
             SerialPrint("\nTransceiver's operating modes:\nMode : ");
             capVal = (regVal >> 2) & 0x7;
             if ( capVal == 0b000 ) {
@@ -575,9 +575,9 @@ void RFM69::readAllRegs()
             SerialPrint ( "\n" );
             break;
         }
-        
+
         case 0x2 : {
-        
+
             SerialPrint("Data Processing mode:\nDataMode : ");
             capVal = (regVal >> 5) & 0x3;
             if ( capVal == 0b00 ) {
@@ -589,7 +589,7 @@ void RFM69::readAllRegs()
             } else if ( capVal == 0b11 ) {
                 SerialPrint ( "11 -> Continuous mode without bit synchronizer\n" );
             }
-            
+
             SerialPrint("\nModulation scheme:\nModulation Type : ");
             capVal = (regVal >> 3) & 0x3;
             if ( capVal == 0b00 ) {
@@ -602,7 +602,7 @@ void RFM69::readAllRegs()
             } else if ( capVal == 0b11 ) {
                 SerialPrint ( "11 -> reserved\n" );
             }
-            
+
             SerialPrint("\nData shaping: ");
             if ( modeFSK ) {
                 SerialPrint( "in FSK:\n" );
@@ -632,16 +632,16 @@ void RFM69::readAllRegs()
                     SerialPrint ( "ERROR - 11 is reserved\n" );
                 }
             }
-            
+
             SerialPrint ( "\n" );
             break;
         }
-        
+
         case 0x3 : {
             bitRate = (regVal << 8);
             break;
         }
-        
+
         case 0x4 : {
             bitRate |= regVal;
             SerialPrint ( "Bit Rate (Chip Rate when Manchester encoding is enabled)\nBitRate : ");
@@ -650,12 +650,12 @@ void RFM69::readAllRegs()
             SerialPrint( "\n" );
             break;
         }
-        
+
         case 0x5 : {
             freqDev = ( (regVal & 0x3f) << 8 );
             break;
         }
-        
+
         case 0x6 : {
             freqDev |= regVal;
             SerialPrint( "Frequency deviation\nFdev : " );
@@ -664,20 +664,20 @@ void RFM69::readAllRegs()
             SerialPrint ( "\n" );
             break;
         }
-        
+
         case 0x7 : {
             unsigned long tempVal = regVal;
             freqCenter = ( tempVal << 16 );
             break;
         }
-       
+
         case 0x8 : {
             unsigned long tempVal = regVal;
             freqCenter = freqCenter | ( tempVal << 8 );
             break;
         }
 
-        case 0x9 : {        
+        case 0x9 : {
             freqCenter = freqCenter | regVal;
             SerialPrint ( "RF Carrier frequency\nFRF : " );
             unsigned long val = 61UL * freqCenter;
@@ -693,7 +693,7 @@ void RFM69::readAllRegs()
             } else {
                 SerialPrint ( "0 -> RC calibration is in progress\n" );
             }
-        
+
             SerialPrint ( "\n" );
             break;
         }
@@ -708,7 +708,7 @@ void RFM69::readAllRegs()
             SerialPrint ( "\n" );
             break;
         }
-        
+
         case 0xc : {
             SerialPrint ( "Reserved\n\n" );
             break;
@@ -727,7 +727,7 @@ void RFM69::readAllRegs()
             } else if ( val == 0b11 ) {
                 SerialPrint ( "11 -> 262 ms\n" );
             }
-            
+
             SerialPrint ( "\nResolution of Listen mode Rx time (calibrated RC osc):\nListenResolRx : " );
             val = (regVal >> 4) & 0x3;
             if ( val == 0b00 ) {
@@ -746,7 +746,7 @@ void RFM69::readAllRegs()
             } else {
                 SerialPrint ( "0 -> signal strength is above RssiThreshold\n" );
             }
-            
+
             SerialPrint ( "\nAction taken after acceptance of a packet in Listen mode:\nListenEnd : " );
             val = (regVal >> 1 ) & 0x3;
             if ( val == 0b00 ) {
@@ -758,12 +758,12 @@ void RFM69::readAllRegs()
             } else if ( val == 0b11 ) {
                 SerialPrint ( "11 -> Reserved\n" );
             }
-            
-            
+
+
             SerialPrint ( "\n" );
             break;
         }
-        
+
         default : {
         }
     }

--- a/RFM69.h
+++ b/RFM69.h
@@ -5,19 +5,19 @@
 // **********************************************************************************
 // License
 // **********************************************************************************
-// This program is free software; you can redistribute it 
-// and/or modify it under the terms of the GNU General    
-// Public License as published by the Free Software       
-// Foundation; either version 3 of the License, or        
-// (at your option) any later version.                    
-//                                                        
-// This program is distributed in the hope that it will   
-// be useful, but WITHOUT ANY WARRANTY; without even the  
-// implied warranty of MERCHANTABILITY or FITNESS FOR A   
-// PARTICULAR PURPOSE. See the GNU General Public        
-// License for more details.                              
-//                                                        
-// Licence can be viewed at                               
+// This program is free software; you can redistribute it
+// and/or modify it under the terms of the GNU General
+// Public License as published by the Free Software
+// Foundation; either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will
+// be useful, but WITHOUT ANY WARRANTY; without even the
+// implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU General Public
+// License for more details.
+//
+// Licence can be viewed at
 // http://www.gnu.org/licenses/gpl-3.0.txt
 //
 // Please maintain this license information along with authorship
@@ -43,9 +43,9 @@
 #elif defined(__arm__)//Use pin 10 or any pin you want
   #define RF69_IRQ_PIN          10
   #define RF69_IRQ_NUM          10
-#else 
+#else
   #define RF69_IRQ_PIN          2
-  #define RF69_IRQ_NUM          0  
+  #define RF69_IRQ_NUM          0
 #endif
 
 

--- a/RFM69.h
+++ b/RFM69.h
@@ -65,7 +65,13 @@
 #define null                  0
 #define COURSE_TEMP_COEF    -90 // puts the temperature reading in the ballpark, user can fine tune the returned value
 #define RF69_BROADCAST_ADDR 255
+
+// 40ms roundtrip req for 61byte packets
+#define DEFAULT_RETRY_WAIT_MS 40
+#define DEFAULT_RETRY_NB       2
+
 #define RF69_CSMA_LIMIT_MS 1000
+#define RF69_CSMA_LIMIT_ACK_MS 35
 #define RF69_TX_LIMIT_MS   1000
 #define RF69_FSTEP  61.03515625 // == FXOSC / 2^19 = 32MHz / 2^19 (p13 in datasheet)
 
@@ -100,7 +106,7 @@ class RFM69 {
     void setNetwork(uint8_t networkID);
     bool canSend();
     virtual void send(uint8_t toAddress, const void* buffer, uint8_t bufferSize, bool requestACK=false);
-    virtual bool sendWithRetry(uint8_t toAddress, const void* buffer, uint8_t bufferSize, uint8_t retries=2, uint8_t retryWaitTime=40); // 40ms roundtrip req for 61byte packets
+    virtual bool sendWithRetry(uint8_t toAddress, const void* buffer, uint8_t bufferSize, uint8_t retries=DEFAULT_RETRY_NB, uint8_t retryWaitTime=DEFAULT_RETRY_WAIT_MS);
     virtual bool receiveDone();
     bool ACKReceived(uint8_t fromNodeID);
     bool ACKRequested();

--- a/RFM69_ATC.cpp
+++ b/RFM69_ATC.cpp
@@ -7,19 +7,19 @@
 // **********************************************************************************
 // License
 // **********************************************************************************
-// This program is free software; you can redistribute it 
-// and/or modify it under the terms of the GNU General    
-// Public License as published by the Free Software       
-// Foundation; either version 3 of the License, or        
-// (at your option) any later version.                    
-//                                                        
-// This program is distributed in the hope that it will   
-// be useful, but WITHOUT ANY WARRANTY; without even the  
-// implied warranty of MERCHANTABILITY or FITNESS FOR A   
-// PARTICULAR PURPOSE. See the GNU General Public        
-// License for more details.                              
-//                                                        
-// Licence can be viewed at                               
+// This program is free software; you can redistribute it
+// and/or modify it under the terms of the GNU General
+// Public License as published by the Free Software
+// Foundation; either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will
+// be useful, but WITHOUT ANY WARRANTY; without even the
+// implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU General Public
+// License for more details.
+//
+// Licence can be viewed at
 // http://www.gnu.org/licenses/gpl-3.0.txt
 //
 // Please maintain this license information along with authorship
@@ -67,7 +67,7 @@ void RFM69_ATC::sendACK(const void* buffer, uint8_t bufferSize) {
   ACK_REQUESTED = 0;   // TomWS1 added to make sure we don't end up in a timing race and infinite loop sending Acks
   uint8_t sender = SENDERID;
   int16_t _RSSI = RSSI; // save payload received RSSI value
-  bool sendRSSI = ACK_RSSI_REQUESTED;  
+  bool sendRSSI = ACK_RSSI_REQUESTED;
   writeReg(REG_PACKETCONFIG2, (readReg(REG_PACKETCONFIG2) & 0xFB) | RF_PACKET2_RXRESTART); // avoid RX deadlocks
   uint32_t now = millis();
   while (!canSend() && millis() - now < RF69_CSMA_LIMIT_MS) receiveDone();
@@ -91,7 +91,7 @@ void RFM69_ATC::sendFrame(uint8_t toAddress, const void* buffer, uint8_t bufferS
   setMode(RF69_MODE_STANDBY); // turn off receiver to prevent reception while filling fifo
   while ((readReg(REG_IRQFLAGS1) & RF_IRQFLAGS1_MODEREADY) == 0x00); // wait for ModeReady
   writeReg(REG_DIOMAPPING1, RF_DIOMAPPING1_DIO0_00); // DIO0 is "Packet Sent"
-  
+
   bufferSize += (sendACK && sendRSSI)?1:0;  // if sending ACK_RSSI then increase data size by 1
   if (bufferSize > RF69_MAX_DATA_LEN) bufferSize = RF69_MAX_DATA_LEN;
 
@@ -207,7 +207,7 @@ void RFM69_ATC::receiveBegin() {
       // if (powerLevel < 50) {
         // _powerLevel = powerLevel - 34;  // leaves 14-15
       // } else {
-        // if (powerLevel > 51) 
+        // if (powerLevel > 51)
           // powerLevel = 51;  // saturate
         // _powerLevel = powerLevel - 36;  // leaves 14-15
       // }
@@ -223,7 +223,7 @@ void RFM69_ATC::receiveBegin() {
 // void RFM69_ATC::setHighPower(bool onOff, byte PA_ctl) {
   // _isRFM69HW = onOff;
   // writeReg(REG_OCP, (_isRFM69HW && PA_ctl==0x60) ? RF_OCP_OFF : RF_OCP_ON);
-  // if (_isRFM69HW) { //turning ON based on module type 
+  // if (_isRFM69HW) { //turning ON based on module type
     // _powerLevel = readReg(REG_PALEVEL) & 0x1F; // make sure internal value matches reg
     // _powerBoost = (PA_ctl == 0x60);
     // _PA_Reg = PA_ctl;

--- a/RFM69_ATC.cpp
+++ b/RFM69_ATC.cpp
@@ -70,7 +70,7 @@ void RFM69_ATC::sendACK(const void* buffer, uint8_t bufferSize) {
   bool sendRSSI = ACK_RSSI_REQUESTED;
   writeReg(REG_PACKETCONFIG2, (readReg(REG_PACKETCONFIG2) & 0xFB) | RF_PACKET2_RXRESTART); // avoid RX deadlocks
   uint32_t now = millis();
-  while (!canSend() && millis() - now < RF69_CSMA_LIMIT_MS) receiveDone();
+  while (!canSend() && millis() - now < RF69_CSMA_LIMIT_ACK_MS) receiveDone();
   SENDERID = sender;    // TomWS1: Restore SenderID after it gets wiped out by receiveDone()
   sendFrame(sender, buffer, bufferSize, false, true, sendRSSI, _RSSI);   // TomWS1: Special override on sendFrame with extra params
   RSSI = _RSSI; // restore payload RSSI

--- a/RFM69_ATC.h
+++ b/RFM69_ATC.h
@@ -43,7 +43,7 @@ class RFM69_ATC: public RFM69 {
     void sendACK(const void* buffer = "", uint8_t bufferSize=0);
     //void setHighPower(bool onOFF=true, uint8_t PA_ctl=0x60); //have to call it after initialize for RFM69HW
     //void setPowerLevel(uint8_t level); // reduce/increase transmit power level
-    bool sendWithRetry(uint8_t toAddress, const void* buffer, uint8_t bufferSize, uint8_t retries=2, uint8_t retryWaitTime=40); // 40ms roundtrip req for 61byte packets
+    bool sendWithRetry(uint8_t toAddress, const void* buffer, uint8_t bufferSize, uint8_t retries=DEFAULT_RETRY_NB, uint8_t retryWaitTime=DEFAULT_RETRY_WAIT_MS);
     void  enableAutoPower(int16_t targetRSSI=-90);  // TWS: New method to enable/disable auto Power control
     void setMode(uint8_t mode);  // TWS: moved from protected to try to build block()/unblock() wrapper
 

--- a/RFM69_ATC.h
+++ b/RFM69_ATC.h
@@ -7,19 +7,19 @@
 // **********************************************************************************
 // License
 // **********************************************************************************
-// This program is free software; you can redistribute it 
-// and/or modify it under the terms of the GNU General    
-// Public License as published by the Free Software       
-// Foundation; either version 3 of the License, or        
-// (at your option) any later version.                    
-//                                                        
-// This program is distributed in the hope that it will   
-// be useful, but WITHOUT ANY WARRANTY; without even the  
-// implied warranty of MERCHANTABILITY or FITNESS FOR A   
-// PARTICULAR PURPOSE. See the GNU General Public        
-// License for more details.                              
-//                                                        
-// Licence can be viewed at                               
+// This program is free software; you can redistribute it
+// and/or modify it under the terms of the GNU General
+// Public License as published by the Free Software
+// Foundation; either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will
+// be useful, but WITHOUT ANY WARRANTY; without even the
+// implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU General Public
+// License for more details.
+//
+// Licence can be viewed at
 // http://www.gnu.org/licenses/gpl-3.0.txt
 //
 // Please maintain this license information along with authorship
@@ -46,7 +46,7 @@ class RFM69_ATC: public RFM69 {
     bool sendWithRetry(uint8_t toAddress, const void* buffer, uint8_t bufferSize, uint8_t retries=2, uint8_t retryWaitTime=40); // 40ms roundtrip req for 61byte packets
     void  enableAutoPower(int16_t targetRSSI=-90);  // TWS: New method to enable/disable auto Power control
     void setMode(uint8_t mode);  // TWS: moved from protected to try to build block()/unblock() wrapper
-    
+
     int16_t getAckRSSI(void);       // TWS: New method to retrieve the ack'd RSSI (if any)
     uint8_t setLNA(uint8_t newReg); // TWS: function to control LNA reg for power testing purposes
     int16_t _targetRSSI;     // if non-zero then this is the desired end point RSSI for our transmission


### PR DESCRIPTION
Hello,

For some reason, I noticed that my packets needed very long to receive the ACK, and figured out that it came from the canSend() in sendACK() waiting for the noise level to get low (which didn't happened in my environment).

Please find here a proposal.
