### PR TITLE
Allow choosing the SPI interface

### DIFF
--- a/RFM69.cpp
+++ b/RFM69.cpp
@@ -85,7 +85,7 @@ bool RFM69::initialize(uint8_t freqBand, uint8_t nodeID, uint8_t networkID)
 
   digitalWrite(_slaveSelectPin, HIGH);
   pinMode(_slaveSelectPin, OUTPUT);
-  SPI.begin();
+  _spi.begin();
   unsigned long start = millis();
   uint8_t timeout = 50;
   do writeReg(REG_SYNCVALUE1, 0xAA); while (readReg(REG_SYNCVALUE1) != 0xaa && millis()-start < timeout);
@@ -287,14 +287,14 @@ void RFM69::sendFrame(uint8_t toAddress, const void* buffer, uint8_t bufferSize,
 
   // write to FIFO
   select();
-  SPI.transfer(REG_FIFO | 0x80);
-  SPI.transfer(bufferSize + 3);
-  SPI.transfer(toAddress);
-  SPI.transfer(_address);
-  SPI.transfer(CTLbyte);
+  _spi.transfer(REG_FIFO | 0x80);
+  _spi.transfer(bufferSize + 3);
+  _spi.transfer(toAddress);
+  _spi.transfer(_address);
+  _spi.transfer(CTLbyte);
 
   for (uint8_t i = 0; i < bufferSize; i++)
-    SPI.transfer(((uint8_t*) buffer)[i]);
+    _spi.transfer(((uint8_t*) buffer)[i]);
   unselect();
 
   // no need to wait for transmit mode to be ready since its handled by the radio
@@ -314,10 +314,10 @@ void RFM69::interruptHandler() {
     //RSSI = readRSSI();
     setMode(RF69_MODE_STANDBY);
     select();
-    SPI.transfer(REG_FIFO & 0x7F);
-    PAYLOADLEN = SPI.transfer(0);
+    _spi.transfer(REG_FIFO & 0x7F);
+    PAYLOADLEN = _spi.transfer(0);
     PAYLOADLEN = PAYLOADLEN > 66 ? 66 : PAYLOADLEN; // precaution
-    TARGETID = SPI.transfer(0);
+    TARGETID = _spi.transfer(0);
     if(!(_promiscuousMode || TARGETID == _address || TARGETID == RF69_BROADCAST_ADDR) // match this node's address, or broadcast address or anything in promiscuous mode
        || PAYLOADLEN < 3) // address situation could receive packets that are malformed and don't fit this libraries extra fields
     {
@@ -329,8 +329,8 @@ void RFM69::interruptHandler() {
     }
 
     DATALEN = PAYLOADLEN - 3;
-    SENDERID = SPI.transfer(0);
-    uint8_t CTLbyte = SPI.transfer(0);
+    SENDERID = _spi.transfer(0);
+    uint8_t CTLbyte = _spi.transfer(0);
 
     ACK_RECEIVED = CTLbyte & RFM69_CTL_SENDACK; // extract ACK-received flag
     ACK_REQUESTED = CTLbyte & RFM69_CTL_REQACK; // extract ACK-requested flag
@@ -339,7 +339,7 @@ void RFM69::interruptHandler() {
 
     for (uint8_t i = 0; i < DATALEN; i++)
     {
-      DATA[i] = SPI.transfer(0);
+      DATA[i] = _spi.transfer(0);
     }
     if (DATALEN < RF69_MAX_DATA_LEN) DATA[DATALEN] = 0; // add null at end of string
     unselect();
@@ -395,9 +395,9 @@ void RFM69::encrypt(const char* key) {
   if (key != 0)
   {
     select();
-    SPI.transfer(REG_AESKEY1 | 0x80);
+    _spi.transfer(REG_AESKEY1 | 0x80);
     for (uint8_t i = 0; i < 16; i++)
-      SPI.transfer(key[i]);
+      _spi.transfer(key[i]);
     unselect();
   }
   writeReg(REG_PACKETCONFIG2, (readReg(REG_PACKETCONFIG2) & 0xFE) | (key ? 1 : 0));
@@ -420,8 +420,8 @@ int16_t RFM69::readRSSI(bool forceTrigger) {
 uint8_t RFM69::readReg(uint8_t addr)
 {
   select();
-  SPI.transfer(addr & 0x7F);
-  uint8_t regval = SPI.transfer(0);
+  _spi.transfer(addr & 0x7F);
+  uint8_t regval = _spi.transfer(0);
   unselect();
   return regval;
 }
@@ -429,8 +429,8 @@ uint8_t RFM69::readReg(uint8_t addr)
 void RFM69::writeReg(uint8_t addr, uint8_t value)
 {
   select();
-  SPI.transfer(addr | 0x80);
-  SPI.transfer(value);
+  _spi.transfer(addr | 0x80);
+  _spi.transfer(value);
   unselect();
 }
 
@@ -443,12 +443,12 @@ void RFM69::select() {
   _SPSR = SPSR;
 #endif
   // set RFM69 SPI settings
-  SPI.setDataMode(SPI_MODE0);
-  SPI.setBitOrder(MSBFIRST);
+  _spi.setDataMode(SPI_MODE0);
+  _spi.setBitOrder(MSBFIRST);
 #ifdef __arm__
-	SPI.setClockDivider(SPI_CLOCK_DIV16);
+	_spi.setClockDivider(SPI_CLOCK_DIV16);
 #else
-  SPI.setClockDivider(SPI_CLOCK_DIV4); // decided to slow down from DIV2 after SPI stalling in some instances, especially visible on mega1284p when RFM69 and FLASH chip both present
+  _spi.setClockDivider(SPI_CLOCK_DIV4); // decided to slow down from DIV2 after SPI stalling in some instances, especially visible on mega1284p when RFM69 and FLASH chip both present
 #endif
   digitalWrite(_slaveSelectPin, LOW);
 }
@@ -527,8 +527,8 @@ void RFM69::readAllRegs()
   for (uint8_t regAddr = 1; regAddr <= 0x4F; regAddr++)
   {
     select();
-    SPI.transfer(regAddr & 0x7F); // send address + r/w bit
-    regVal = SPI.transfer(0);
+    _spi.transfer(regAddr & 0x7F); // send address + r/w bit
+    regVal = _spi.transfer(0);
     unselect();
 
     Serial.print(regAddr, HEX);

--- a/RFM69.h
+++ b/RFM69.h
@@ -26,6 +26,7 @@
 #ifndef RFM69_h
 #define RFM69_h
 #include <Arduino.h>            // assumes Arduino IDE v1.0 or greater
+#include <SPI.h>
 
 #define RF69_MAX_DATA_LEN       61 // to take advantage of the built in AES/CRC we want to limit the frame size to the internal FIFO size (66 bytes - 3 bytes overhead - 2 bytes crc)
 #define RF69_SPI_CS             SS // SS is the SPI slave select pin, for instance D10 on ATmega328
@@ -85,7 +86,7 @@ class RFM69 {
     static volatile int16_t RSSI; // most accurate RSSI during reception (closest to the reception)
     static volatile uint8_t _mode; // should be protected?
 
-    RFM69(uint8_t slaveSelectPin=RF69_SPI_CS, uint8_t interruptPin=RF69_IRQ_PIN, bool isRFM69HW=false, uint8_t interruptNum=RF69_IRQ_NUM) {
+    RFM69(uint8_t slaveSelectPin=RF69_SPI_CS, uint8_t interruptPin=RF69_IRQ_PIN, bool isRFM69HW=false, uint8_t interruptNum=RF69_IRQ_NUM, SPIClass &spi = SPI) {
       _slaveSelectPin = slaveSelectPin;
       _interruptPin = interruptPin;
       _interruptNum = interruptNum;
@@ -93,6 +94,7 @@ class RFM69 {
       _promiscuousMode = false;
       _powerLevel = 31;
       _isRFM69HW = isRFM69HW;
+      _spi = spi;
     }
 
     bool initialize(uint8_t freqBand, uint8_t ID, uint8_t networkID=1);
@@ -138,6 +140,7 @@ class RFM69 {
     bool _promiscuousMode;
     uint8_t _powerLevel;
     bool _isRFM69HW;
+    SPIClass _spi = SPI;
 #if defined (SPCR) && defined (SPSR)
     uint8_t _SPCR;
     uint8_t _SPSR;

--- a/RFM69_OTA.cpp
+++ b/RFM69_OTA.cpp
@@ -30,7 +30,7 @@
 // Please maintain this license information along with authorship
 // and copyright notices in any redistribution of this code
 // **********************************************************************************
-#ifndef __arm__
+#ifdef __AVR__
 #include <RFM69_OTA.h>
 #include <RFM69registers.h>
 #include <avr/wdt.h>
@@ -518,4 +518,4 @@ void resetUsingWatchdog(uint8_t DEBUG)
   wdt_enable(WDTO_15MS);
   while(1) if (DEBUG) Serial.print(F("."));
 }
-#endif
+#endif // __AVR__

--- a/RFM69_OTA.h
+++ b/RFM69_OTA.h
@@ -30,7 +30,7 @@
 // Please maintain this license information along with authorship
 // and copyright notices in any redistribution of this code
 // **********************************************************************************
-#ifndef __arm__
+#ifdef __AVR__
 
 #ifndef RFM69_OTA_H
 #define RFM69_OTA_H
@@ -78,5 +78,5 @@ uint8_t BYTEfromHEX(char MSB, char LSB);
 uint8_t readSerialLine(char* input, char endOfLineChar=10, uint8_t maxLength=115, uint16_t timeout=1000);
 void PrintHex83(uint8_t* data, uint8_t length);
 
-#endif
-#endif
+#endif // RFM69_OTA_H
+#endif // __AVR__


### PR DESCRIPTION
This allows the caller to specify a specific SPIClass when constructing RFM69. This is useful on ARM boards that have multiple SPI interfaces. Defaults to SPI, so it preserves existing behavior.

Also disables RFM69_OTA if the arch isn't AVR, since it depends on the AVR watchdog #56 .