### PR TITLE
Allow choosing the SPI interface

### DIFF
--- a/RFM69.cpp
+++ b/RFM69.cpp
@@ -108,11 +108,12 @@ bool RFM69::initialize(uint8_t freqBand, uint8_t nodeID, uint8_t networkID)
 
   digitalWrite(_slaveSelectPin, HIGH);
   pinMode(_slaveSelectPin, OUTPUT);
-  _spi.begin();
-  
-#ifdef SPI_HAS_TRANSACTION
+
+  if (_spi == nullptr) {
+    _spi = &SPI;
+  }
+  _spi->begin();
   _settings = SPISettings(4000000, MSBFIRST, SPI_MODE0);
-#endif
 
   unsigned long start = millis();
   uint8_t timeout = 50;

--- a/RFM69.h
+++ b/RFM69.h
@@ -123,7 +123,11 @@
   #define RF69_IRQ_PIN          9
 #elif defined(ARDUINO_SAMD_ZERO) //includes Feather SAMD
   #define RF69_IRQ_PIN          3
-#else
+  #define RF69_IRQ_NUM          0
+#elif defined(__arm__)//Use pin 10 or any pin you want
+  #define RF69_IRQ_PIN          PA3
+  #define RF69_IRQ_NUM          3
+#else 
   #define RF69_IRQ_PIN          2
 #endif
 
@@ -175,7 +179,7 @@ class RFM69 {
     RFM69(uint8_t slaveSelectPin, uint8_t interruptPin, bool isRFM69HW, uint8_t interruptNum) //interruptNum is now deprecated
                 : RFM69(slaveSelectPin, interruptPin, isRFM69HW){};
 
-    RFM69(uint8_t slaveSelectPin=RF69_SPI_CS, uint8_t interruptPin=RF69_IRQ_PIN, bool isRFM69HW=false);
+    RFM69(uint8_t slaveSelectPin=RF69_SPI_CS, uint8_t interruptPin=RF69_IRQ_PIN, bool isRFM69HW=false, SPIClass *spi=nullptr);
 
     bool initialize(uint8_t freqBand, uint8_t ID, uint8_t networkID=1);
     void setAddress(uint8_t addr);
@@ -220,6 +224,7 @@ class RFM69 {
     bool _promiscuousMode;
     uint8_t _powerLevel;
     bool _isRFM69HW;
+    SPIClass *_spi;
 #if defined (SPCR) && defined (SPSR)
     uint8_t _SPCR;
     uint8_t _SPSR;

--- a/RFM69.h
+++ b/RFM69.h
@@ -123,11 +123,7 @@
   #define RF69_IRQ_PIN          9
 #elif defined(ARDUINO_SAMD_ZERO) //includes Feather SAMD
   #define RF69_IRQ_PIN          3
-  #define RF69_IRQ_NUM          0
-#elif defined(__arm__)//Use pin 10 or any pin you want
-  #define RF69_IRQ_PIN          PA3
-  #define RF69_IRQ_NUM          3
-#else 
+#else
   #define RF69_IRQ_PIN          2
 #endif
 

--- a/RFM69_ATC.h
+++ b/RFM69_ATC.h
@@ -36,8 +36,8 @@ class RFM69_ATC: public RFM69 {
   public:
     static volatile uint8_t ACK_RSSI_REQUESTED;  // new flag in CTL byte to request RSSI with ACK (could potentially be merged with ACK_REQUESTED)
 
-    RFM69_ATC(uint8_t slaveSelectPin=RF69_SPI_CS, uint8_t interruptPin=RF69_IRQ_PIN, bool isRFM69HW=false, uint8_t interruptNum=0) :
-      RFM69(slaveSelectPin, interruptPin, isRFM69HW) {
+    RFM69_ATC(uint8_t slaveSelectPin=RF69_SPI_CS, uint8_t interruptPin=RF69_IRQ_PIN, bool isRFM69HW=false, uint8_t interruptNum=0, SPIClass *spi=nullptr) :
+      RFM69(slaveSelectPin, interruptPin, isRFM69HW, spi) {
     }
 
     bool initialize(uint8_t freqBand, uint8_t ID, uint8_t networkID=1);


### PR DESCRIPTION
Allow choosing the SPI interface.

Follow up to #93. This time, use a pointer for the SPI object so that we can default it to SPI in initialize.