### PR TITLE
Explicitly re-enable interrupts in receiveDone

### DIFF
--- a/RFM69.cpp
+++ b/RFM69.cpp
@@ -403,7 +403,8 @@ bool RFM69::receiveDone() {
   noInterrupts(); // re-enabled in unselect() via setMode() or via receiveBegin()
   if (_mode == RF69_MODE_RX && PAYLOADLEN > 0)
   {
-    setMode(RF69_MODE_STANDBY); // enables interrupts
+    setMode(RF69_MODE_STANDBY);
+    interrupts(); // explicitly re-enable interrupts
     return true;
   }
   else if (_mode == RF69_MODE_RX) // already in RX no payload yet
@@ -412,6 +413,7 @@ bool RFM69::receiveDone() {
     return false;
   }
   receiveBegin();
+  interrupts(); // explicitly re-enable interrupts
   return false;
 //}
 }


### PR DESCRIPTION
The comment stated that setMode would re-enable interrupts, but it doesn't look like the code does that. This is causing problems for me on a SAMD21-based custom board - it causes subsequent calls to delay() to hang forever. The Arduino time is implemented by an interrupt every millisecond to increment the time, so I think that this is the culprit.