### PR TITLE
Use relative includes

### DIFF
--- a/RFM69.cpp
+++ b/RFM69.cpp
@@ -23,8 +23,9 @@
 // Please maintain this license information along with authorship
 // and copyright notices in any redistribution of this code
 // **********************************************************************************
-#include <RFM69.h>
-#include <RFM69registers.h>
+#include "RFM69.h"
+#include "RFM69registers.h"
+
 #include <SPI.h>
 
 uint8_t RFM69::DATA[RF69_MAX_DATA_LEN+1];

--- a/RFM69_ATC.cpp
+++ b/RFM69_ATC.cpp
@@ -26,9 +26,10 @@
 // Please maintain this license information along with authorship
 // and copyright notices in any redistribution of this code
 // **********************************************************************************
-#include <RFM69_ATC.h>
-#include <RFM69.h>   // include the RFM69 library files as well
-#include <RFM69registers.h>
+#include "RFM69_ATC.h"
+#include "RFM69.h"   // include the RFM69 library files as well
+#include "RFM69registers.h"
+
 #include <SPI.h>
 
 volatile uint8_t RFM69_ATC::ACK_RSSI_REQUESTED;  // new type of flag on ACK_REQUEST

--- a/RFM69_ATC.h
+++ b/RFM69_ATC.h
@@ -28,7 +28,7 @@
 // **********************************************************************************
 #ifndef RFM69_ATC_h
 #define RFM69_ATC_h
-#include <RFM69.h>
+#include "RFM69.h"
 
 #define RFM69_CTL_RESERVE1  0x20
 

--- a/RFM69_OTA.cpp
+++ b/RFM69_OTA.cpp
@@ -30,8 +30,8 @@
 // Please maintain this license information along with authorship
 // and copyright notices in any redistribution of this code
 // **********************************************************************************
-#include <RFM69_OTA.h>
-#include <RFM69registers.h>
+#include "RFM69_OTA.h"
+#include "RFM69registers.h"
 
 #ifdef __AVR__
   #include <avr/wdt.h>

--- a/RFM69_OTA.h
+++ b/RFM69_OTA.h
@@ -34,7 +34,7 @@
 #ifndef RFM69_OTA_H
 #define RFM69_OTA_H
 
-#include <RFM69.h>
+#include "RFM69.h"
 #include <SPIFlash.h>
 
 #if defined(MOTEINO_M0)


### PR DESCRIPTION
Hey,

I've been doing some refactoring and discovered strange include problem with having rfm69.h file in my project directory. Using platformio on Windows, it does not distinguish RFM69.h and rfm69.h b/c of case insensitive filesystem.
I am not yet sure why exactly platformio uses global include path like that, but in any case I think it would be a useful change here to have relative include instead of absolute to signify that we are using local headers and not some external ones.