### PR TITLE
Custom SPI support

### DIFF
--- a/RFM69.h
+++ b/RFM69.h
@@ -197,7 +197,7 @@ class RFM69 {
     RFM69(uint8_t slaveSelectPin, uint8_t interruptPin, bool isRFM69HW, uint8_t interruptNum) //interruptNum is now deprecated
                 : RFM69(slaveSelectPin, interruptPin, isRFM69HW){};
 
-    RFM69(uint8_t slaveSelectPin=RF69_SPI_CS, uint8_t interruptPin=RF69_IRQ_PIN, bool isRFM69HW=false);
+    RFM69(uint8_t slaveSelectPin=RF69_SPI_CS, uint8_t interruptPin=RF69_IRQ_PIN, bool isRFM69HW=false, SPIClass *spi=nullptr);
 
     bool initialize(uint8_t freqBand, uint16_t ID, uint8_t networkID=1);
     void setAddress(uint16_t addr);
@@ -249,6 +249,7 @@ class RFM69 {
     bool _spyMode;
     uint8_t _powerLevel;
     bool _isRFM69HW;
+    SPIClass *_spi;
 #if defined (SPCR) && defined (SPSR)
     uint8_t _SPCR;
     uint8_t _SPSR;

--- a/RFM69_ATC.cpp
+++ b/RFM69_ATC.cpp
@@ -99,29 +99,29 @@ void RFM69_ATC::sendFrame(uint16_t toAddress, const void* buffer, uint8_t buffer
 
   // write to FIFO
   select();
-  SPI.transfer(REG_FIFO | 0x80);
-  SPI.transfer(bufferSize + 3);
-  SPI.transfer((uint8_t)toAddress); //lower 8bits
-  SPI.transfer((uint8_t)_address);  //lower 8bits
+  _spi->transfer(REG_FIFO | 0x80);
+  _spi->transfer(bufferSize + 3);
+  _spi->transfer((uint8_t)toAddress); //lower 8bits
+  _spi->transfer((uint8_t)_address);  //lower 8bits
 
   // CTL (control byte)
   uint8_t CTLbyte=0x0;
   if (toAddress > 0xFF) CTLbyte |= (toAddress & 0x300) >> 6; //assign last 2 bits of address if > 255
   if (_address > 0xFF) CTLbyte |= (_address & 0x300) >> 8;   //assign last 2 bits of address if > 255
   if (sendACK) {                   // TomWS1: adding logic to return ACK_RSSI if requested
-    SPI.transfer(CTLbyte | RFM69_CTL_SENDACK | (sendRSSI?RFM69_CTL_RESERVE1:0));  // TomWS1  TODO: Replace with EXT1
+    _spi->transfer(CTLbyte | RFM69_CTL_SENDACK | (sendRSSI?RFM69_CTL_RESERVE1:0));  // TomWS1  TODO: Replace with EXT1
     if (sendRSSI) {
-      SPI.transfer(abs(lastRSSI)); //RSSI dBm is negative expected between [-100 .. -20], convert to positive and pass along as single extra header byte
+      _spi->transfer(abs(lastRSSI)); //RSSI dBm is negative expected between [-100 .. -20], convert to positive and pass along as single extra header byte
       bufferSize -=1;              // account for the extra ACK-RSSI 'data' byte
     }
   }
   else if (requestACK) {  // TODO: add logic to request ackRSSI with ACK - this is when both ends of a transmission would dial power down. May not work well for gateways in multi node networks
-    SPI.transfer(CTLbyte | (_targetRSSI ? RFM69_CTL_REQACK | RFM69_CTL_RESERVE1 : RFM69_CTL_REQACK));
+    _spi->transfer(CTLbyte | (_targetRSSI ? RFM69_CTL_REQACK | RFM69_CTL_RESERVE1 : RFM69_CTL_REQACK));
   }
-  else SPI.transfer(CTLbyte);
+  else _spi->transfer(CTLbyte);
 
   for (uint8_t i = 0; i < bufferSize; i++)
-    SPI.transfer(((uint8_t*) buffer)[i]);
+    _spi->transfer(((uint8_t*) buffer)[i]);
   unselect();
 
   // no need to wait for transmit mode to be ready since its handled by the radio
@@ -141,7 +141,7 @@ void RFM69_ATC::interruptHook(uint8_t CTLbyte) {
   if (ACK_RECEIVED && ACK_RSSI_REQUESTED) {
     // the next two bytes contain the ACK_RSSI (assuming the datalength is valid)
     if (DATALEN >= 1) {
-      _ackRSSI = -1 * SPI.transfer(0); //rssi was sent as single byte positive value, get the real value by * -1
+      _ackRSSI = -1 * _spi->transfer(0); //rssi was sent as single byte positive value, get the real value by * -1
       DATALEN -= 1;   // and compensate data length accordingly
       // TomWS1: Now dither transmitLevel value (register update occurs later when transmitting);
       if (_targetRSSI != 0) {

--- a/RFM69_ATC.h
+++ b/RFM69_ATC.h
@@ -36,7 +36,7 @@ class RFM69_ATC: public RFM69 {
   public:
     static volatile uint8_t ACK_RSSI_REQUESTED;  // new flag in CTL byte to request RSSI with ACK (could potentially be merged with ACK_REQUESTED)
 
-    RFM69_ATC(uint8_t slaveSelectPin=RF69_SPI_CS, uint8_t interruptPin=RF69_IRQ_PIN, bool isRFM69HW=false, uint8_t interruptNum=0, SPIClass *spi=nullptr) :
+    RFM69_ATC(uint8_t slaveSelectPin=RF69_SPI_CS, uint8_t interruptPin=RF69_IRQ_PIN, bool isRFM69HW=false, SPIClass *spi=nullptr) :
       RFM69(slaveSelectPin, interruptPin, isRFM69HW, spi) {
     }
 

--- a/RFM69_ATC.h
+++ b/RFM69_ATC.h
@@ -36,8 +36,8 @@ class RFM69_ATC: public RFM69 {
   public:
     static volatile uint8_t ACK_RSSI_REQUESTED;  // new flag in CTL byte to request RSSI with ACK (could potentially be merged with ACK_REQUESTED)
 
-    RFM69_ATC(uint8_t slaveSelectPin=RF69_SPI_CS, uint8_t interruptPin=RF69_IRQ_PIN, bool isRFM69HW=false, uint8_t interruptNum=0) :
-      RFM69(slaveSelectPin, interruptPin, isRFM69HW) {
+    RFM69_ATC(uint8_t slaveSelectPin=RF69_SPI_CS, uint8_t interruptPin=RF69_IRQ_PIN, bool isRFM69HW=false, uint8_t interruptNum=0, SPIClass *spi=nullptr) :
+      RFM69(slaveSelectPin, interruptPin, isRFM69HW, spi) {
     }
 
     bool initialize(uint8_t freqBand, uint16_t ID, uint8_t networkID=1);


### PR DESCRIPTION
There is an old [open issue](https://github.com/LowPowerLab/RFM69/pull/100) about adding SPI support, that I didn't open. This new one seems to be working.

I added a few changes so we can pass a predefined SPIClass into the constructor.

For example with a MKR1000 (SAMD) board, we can define a new SPI bus on pins 0,1 and 6:
`SPIClass mySPI (&sercom3, 6, 1, 0, SPI_PAD_0_SCK_1, SERCOM_RX_PAD_2); //MISO(6), SCK(1), MOSI(0)`

And later we can call the constructor with additional parameters if we want:
`#ifdef ENABLE_ATC`
`RFM69_ATC radio(RFM69_CS, A2, is_rfm69hw_hcw, &mySPI);`
`#else`
`RFM69 radio(RFM69_CS, A2, is_rfm69hw_hcw, &mySPI);`
`#endif`

I can confirm it is working as of 02 June 2020 with MKR1000 and not interfering with standard Moteino (-USB), and very likely with any other one (neither the hardcoded ESP32 SPI, at RFM69.cpp, which could be supported this way, probably).