### PR TITLE
Bugfix/stm32 f1 not working

### DIFF
--- a/RFM69.cpp
+++ b/RFM69.cpp
@@ -550,7 +550,7 @@ void RFM69::setCS(uint8_t newSPISlaveSelect) {
 }
 
 // set the IRQ pin
-bool setIrq(uint8_t newIRQPin) {
+bool RFM69::setIrq(uint8_t newIRQPin) {
   uint8_t _newInterruptNum = digitalPinToInterrupt(newIRQPin);
   if (_newInterruptNum == NOT_AN_INTERRUPT) return false;
 #ifdef RF69_ATTACHINTERRUPT_TAKES_PIN_NUMBER

--- a/RFM69.cpp
+++ b/RFM69.cpp
@@ -549,6 +549,23 @@ void RFM69::setCS(uint8_t newSPISlaveSelect) {
   pinMode(_slaveSelectPin, OUTPUT);
 }
 
+// set the IRQ pin
+bool setIrq(uint8_t newIRQPin) {
+  uint8_t _newInterruptNum = digitalPinToInterrupt(newIRQPin);
+  if (_newInterruptNum == NOT_AN_INTERRUPT) return false;
+#ifdef RF69_ATTACHINTERRUPT_TAKES_PIN_NUMBER
+  _newInterruptNum = newIRQPin;
+#endif
+
+  // disconnect from existing IRQ pin
+  detachInterrupt( _interruptNum );
+
+  _interruptNum = _newInterruptNum;
+  attachInterrupt(_interruptNum, RFM69::isr0, RISING);
+
+  return true;
+}
+
 //for debugging
 #define REGISTER_DETAIL 0
 #if REGISTER_DETAIL

--- a/RFM69.h
+++ b/RFM69.h
@@ -127,8 +127,9 @@
   #define RF69_IRQ_PIN          2
 #elif defined(__AVR_ATmega32U4__)
   #define RF69_IRQ_PIN          7
-#elif defined(__STM32F1__)
+#elif defined(__STM32F1__) || defined(STM32F1)
   #define RF69_IRQ_PIN          PA3
+  #define RF69_ATTACHINTERRUPT_TAKES_PIN_NUMBER
 #elif defined(MOTEINO_M0)
   #define RF69_IRQ_PIN          9
 #elif defined(__SAMD51__)
@@ -215,6 +216,7 @@ class RFM69 {
     void setFrequency(uint32_t freqHz);
     void encrypt(const char* key);
     void setCS(uint8_t newSPISlaveSelect);
+    bool setIrq(uint8_t newIRQPin);
     int16_t readRSSI(bool forceTrigger=false); // *current* signal strength indicator; e.g. < -90dBm says the frequency channel is free + ready to transmit
     void spyMode(bool onOff=true);
     //void promiscuous(bool onOff=true); //replaced with spyMode()

--- a/keywords.txt
+++ b/keywords.txt
@@ -29,6 +29,7 @@ setFrequency	KEYWORD2
 getFrequency	KEYWORD2
 encrypt	KEYWORD2
 setCS	KEYWORD2
+setIrq	KEYWORD2
 readRSSI	KEYWORD2
 spyMode	KEYWORD2
 setHighPower	KEYWORD2


### PR DESCRIPTION
See linked ticket.
Fix define to work with [Arduino_Core_STM32](https://github.com/stm32duino/Arduino_Core_STM32)