### PR TITLE
Do not redefine RF69_SPI_CS

### DIFF
--- a/RFM69.h
+++ b/RFM69.h
@@ -118,6 +118,8 @@
 #endif
 ////////////////////////////////////////////////////
 
+#define RF69_SPI_CS             SS // SS is the SPI slave select pin, for instance D10 on ATmega328
+
 // INT0 on AVRs should be connected to RFM69's DIO0 (ex on ATmega328 it's D2, on ATmega644/1284 it's D2)
 #if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__) || defined(__AVR_ATmega88) || defined(__AVR_ATmega8__) || defined(__AVR_ATmega88__)
   #define RF69_IRQ_PIN          2
@@ -141,8 +143,6 @@
 #else
   #define RF69_IRQ_PIN          2
 #endif
-
-#define RF69_SPI_CS             SS // SS is the SPI slave select pin, for instance D10 on ATmega328
 
 #define RF69_MAX_DATA_LEN       61 // to take advantage of the built in AES/CRC we want to limit the frame size to the internal FIFO size (66 bytes - 3 bytes overhead - 2 bytes crc)
 #define CSMA_LIMIT              -90 // upper RX signal sensitivity threshold in dBm for carrier sense access

--- a/RFM69.h
+++ b/RFM69.h
@@ -118,8 +118,6 @@
 #endif
 ////////////////////////////////////////////////////
 
-#define RF69_SPI_CS             SS // SS is the SPI slave select pin, for instance D10 on ATmega328
-
 // INT0 on AVRs should be connected to RFM69's DIO0 (ex on ATmega328 it's D2, on ATmega644/1284 it's D2)
 #if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__) || defined(__AVR_ATmega88) || defined(__AVR_ATmega8__) || defined(__AVR_ATmega88__)
   #define RF69_IRQ_PIN          2
@@ -138,13 +136,13 @@
   #define RF69_IRQ_PIN          3
 #elif defined(ESP8266)
   #define RF69_IRQ_PIN          4
-  #define RF69_SPI_CS           15
 #elif defined(ESP32)
   #define RF69_IRQ_PIN          2
-  #define RF69_SPI_CS           5
 #else
   #define RF69_IRQ_PIN          2
 #endif
+
+#define RF69_SPI_CS             SS // SS is the SPI slave select pin, for instance D10 on ATmega328
 
 #define RF69_MAX_DATA_LEN       61 // to take advantage of the built in AES/CRC we want to limit the frame size to the internal FIFO size (66 bytes - 3 bytes overhead - 2 bytes crc)
 #define CSMA_LIMIT              -90 // upper RX signal sensitivity threshold in dBm for carrier sense access


### PR DESCRIPTION
Noticed here:
https://github.com/xoseperez/espurna/runs/1757526551?check_suite_focus=true#step:9:290

Avoids `RFM69.h:141:0: warning: "RF69_SPI_CS" redefined [enabled by default]'
Remove esp8266 & esp32 flags, always infer the value through SS
Move definition down to stand out a bit more

My understanding is that we always have `SS` through the Arduino.h 'variant' constants
(but I guess originally this was not the case?)