### PR TITLE
fixing some warnings

### DIFF
--- a/RFM69.cpp
+++ b/RFM69.cpp
@@ -551,7 +551,7 @@ void RFM69::setCS(uint8_t newSPISlaveSelect) {
 
 // set the IRQ pin
 bool RFM69::setIrq(uint8_t newIRQPin) {
-  uint8_t _newInterruptNum = digitalPinToInterrupt(newIRQPin);
+  int _newInterruptNum = digitalPinToInterrupt(newIRQPin);
   if (_newInterruptNum == NOT_AN_INTERRUPT) return false;
 #ifdef RF69_ATTACHINTERRUPT_TAKES_PIN_NUMBER
   _newInterruptNum = newIRQPin;

--- a/RFM69.cpp
+++ b/RFM69.cpp
@@ -59,7 +59,7 @@ RFM69::RFM69(uint8_t slaveSelectPin, uint8_t interruptPin, bool isRFM69HW, SPICl
 bool RFM69::initialize(uint8_t freqBand, uint16_t nodeID, uint8_t networkID)
 {
   _interruptNum = digitalPinToInterrupt(_interruptPin);
-  if (_interruptNum == NOT_AN_INTERRUPT) return false;
+  if (_interruptNum == (uint8_t)NOT_AN_INTERRUPT) return false;
 #ifdef RF69_ATTACHINTERRUPT_TAKES_PIN_NUMBER
     _interruptNum = _interruptPin;
 #endif
@@ -551,8 +551,8 @@ void RFM69::setCS(uint8_t newSPISlaveSelect) {
 
 // set the IRQ pin
 bool RFM69::setIrq(uint8_t newIRQPin) {
-  int _newInterruptNum = digitalPinToInterrupt(newIRQPin);
-  if (_newInterruptNum == NOT_AN_INTERRUPT) return false;
+  uint8_t _newInterruptNum = digitalPinToInterrupt(newIRQPin);
+  if (_newInterruptNum == (uint8_t)NOT_AN_INTERRUPT) return false;
 #ifdef RF69_ATTACHINTERRUPT_TAKES_PIN_NUMBER
   _newInterruptNum = newIRQPin;
 #endif

--- a/RFM69.h
+++ b/RFM69.h
@@ -195,7 +195,7 @@ class RFM69 {
     static int16_t RSSI; // most accurate RSSI during reception (closest to the reception). RSSI of last packet.
     static uint8_t _mode; // should be protected?
 
-    RFM69(uint8_t slaveSelectPin, uint8_t interruptPin, bool isRFM69HW, uint8_t interruptNum) //interruptNum is now deprecated
+    RFM69(uint8_t slaveSelectPin, uint8_t interruptPin, bool isRFM69HW, uint8_t interruptNum __attribute__((unused))) //interruptNum is now deprecated
                 : RFM69(slaveSelectPin, interruptPin, isRFM69HW){};
 
     RFM69(uint8_t slaveSelectPin=RF69_SPI_CS, uint8_t interruptPin=RF69_IRQ_PIN, bool isRFM69HW=false, SPIClass *spi=nullptr);
@@ -238,7 +238,7 @@ class RFM69 {
   protected:
     static void isr0();
     void interruptHandler();
-    virtual void interruptHook(uint8_t CTLbyte) {};
+    virtual void interruptHook(uint8_t CTLbyte __attribute__((unused))) {};
     static volatile bool _haveData;
     virtual void sendFrame(uint16_t toAddress, const void* buffer, uint8_t size, bool requestACK=false, bool sendACK=false);
 
@@ -247,7 +247,7 @@ class RFM69 {
    
     uint8_t _slaveSelectPin;
     uint8_t _interruptPin;
-    uint8_t _interruptNum;
+    int _interruptNum;
     uint16_t _address;
     bool _spyMode;
     uint8_t _powerLevel;

--- a/RFM69.h
+++ b/RFM69.h
@@ -247,7 +247,7 @@ class RFM69 {
    
     uint8_t _slaveSelectPin;
     uint8_t _interruptPin;
-    int _interruptNum;
+    uint8_t _interruptNum;
     uint16_t _address;
     bool _spyMode;
     uint8_t _powerLevel;

--- a/RFM69_OTA.cpp
+++ b/RFM69_OTA.cpp
@@ -510,7 +510,13 @@ uint8_t sendHEXPacket(RFM69& radio, uint16_t targetID, uint8_t* sendBuf, uint8_t
           radio.DATA[ackLen-2]=='O' && radio.DATA[ackLen-1]=='K')
       {
         uint16_t tmp=0;
-        sscanf((const char*)radio.DATA, "FLX:%" PRIu16 ":OK", &tmp);
+#if defined(__arm__)
+        // On the ARM platform, uint16_t = short unsigned int, so %hu formatting is needed:
+        sscanf((const char*)radio.DATA, "FLX:%hu:OK", &tmp);
+#else
+        // On the AVR platform, uint16_t = unsigned int, so %u formatting is needed:
+        sscanf((const char*)radio.DATA, "FLX:%u:OK", &tmp);
+#endif
         return tmp == seq;
       }
     }

--- a/RFM69_OTA.cpp
+++ b/RFM69_OTA.cpp
@@ -510,7 +510,7 @@ uint8_t sendHEXPacket(RFM69& radio, uint16_t targetID, uint8_t* sendBuf, uint8_t
           radio.DATA[ackLen-2]=='O' && radio.DATA[ackLen-1]=='K')
       {
         uint16_t tmp=0;
-        sscanf((const char*)radio.DATA, "FLX:%hu:OK", &tmp);
+        sscanf((const char*)radio.DATA, "FLX:%u:OK", &tmp);
         return tmp == seq;
       }
     }

--- a/RFM69_OTA.cpp
+++ b/RFM69_OTA.cpp
@@ -510,7 +510,7 @@ uint8_t sendHEXPacket(RFM69& radio, uint16_t targetID, uint8_t* sendBuf, uint8_t
           radio.DATA[ackLen-2]=='O' && radio.DATA[ackLen-1]=='K')
       {
         uint16_t tmp=0;
-        sscanf((const char*)radio.DATA, "FLX:%u:OK", &tmp);
+        sscanf((const char*)radio.DATA, "FLX:%" PRIu16 ":OK", &tmp);
         return tmp == seq;
       }
     }


### PR DESCRIPTION
Some information: 
* In the Arduino library, the interrupt number is a uint8_t, but NOT_AN_INTERRUPT is defined as -1! So this isn't logic, and as the function digitalPinToInterrupt can return -1, the variable should be a signed integer
* Added some "unused" attributes to tell the compiler to not car about the unused variables
* The formatting of uint16_t is %u and not %hu (https://en.wikipedia.org/wiki/C_data_types) as uint16_t = unsigned int