### PR TITLE
ISR callback in a user space

### DIFF
--- a/RFM69.cpp
+++ b/RFM69.cpp
@@ -154,11 +154,6 @@ bool RFM69::initialize(uint8_t freqBand, uint16_t nodeID, uint8_t networkID)
   return true;
 }
 
-void RFM69::setIsrCallback(void (*callback)())
-{
-  _isrCallback = callback;
-}
-
 // return the frequency (in Hz)
 uint32_t RFM69::getFrequency()
 {
@@ -232,6 +227,12 @@ void RFM69::setAddress(uint16_t addr)
 void RFM69::setNetwork(uint8_t networkID)
 {
   writeReg(REG_SYNCVALUE2, networkID);
+}
+
+//set user's ISR callback
+void RFM69::setIsrCallback(void (*callback)())
+{
+  _isrCallback = callback;
 }
 
 // Control transmitter output power (this is NOT a dBm value!)

--- a/RFM69.h
+++ b/RFM69.h
@@ -201,6 +201,7 @@ class RFM69 {
     RFM69(uint8_t slaveSelectPin=RF69_SPI_CS, uint8_t interruptPin=RF69_IRQ_PIN, bool isRFM69HW_HCW=false, SPIClass *spi=nullptr);
 
     bool initialize(uint8_t freqBand, uint16_t ID, uint8_t networkID=1);
+    void setIsrCallback(void (*callback)());
     void setAddress(uint16_t addr);
     void setNetwork(uint8_t networkID);
     virtual bool canSend();
@@ -247,6 +248,8 @@ class RFM69 {
     void interruptHandler();
     virtual void interruptHook(uint8_t CTLbyte __attribute__((unused))) {};
     static volatile bool _haveData;
+    static RFM69 *_instance;
+    void (*_isrCallback)() = nullptr;
     virtual void sendFrame(uint16_t toAddress, const void* buffer, uint8_t size, bool requestACK=false, bool sendACK=false);
 
     // for ListenMode sleep/timer

--- a/RFM69.h
+++ b/RFM69.h
@@ -201,9 +201,9 @@ class RFM69 {
     RFM69(uint8_t slaveSelectPin=RF69_SPI_CS, uint8_t interruptPin=RF69_IRQ_PIN, bool isRFM69HW_HCW=false, SPIClass *spi=nullptr);
 
     bool initialize(uint8_t freqBand, uint16_t ID, uint8_t networkID=1);
-    void setIsrCallback(void (*callback)());
     void setAddress(uint16_t addr);
     void setNetwork(uint8_t networkID);
+    void setIsrCallback(void (*callback)());
     virtual bool canSend();
     virtual void send(uint16_t toAddress, const void* buffer, uint8_t bufferSize, bool requestACK=false);
     virtual bool sendWithRetry(uint16_t toAddress, const void* buffer, uint8_t bufferSize, uint8_t retries=2, uint8_t retryWaitTime=RFM69_ACK_TIMEOUT);
@@ -249,7 +249,6 @@ class RFM69 {
     virtual void interruptHook(uint8_t CTLbyte __attribute__((unused))) {};
     static volatile bool _haveData;
     static RFM69 *_instance;
-    void (*_isrCallback)() = nullptr;
     virtual void sendFrame(uint16_t toAddress, const void* buffer, uint8_t size, bool requestACK=false, bool sendACK=false);
 
     // for ListenMode sleep/timer
@@ -263,6 +262,7 @@ class RFM69 {
     uint8_t _powerLevel;
     bool _isRFM69HW;
     SPIClass *_spi;
+    void (*_isrCallback)() = nullptr;
 #if defined (SPCR) && defined (SPSR)
     uint8_t _SPCR;
     uint8_t _SPSR;


### PR DESCRIPTION
This library works well on ESP32, and I've been using it for a couple of years to re-send data from low-power nodes to an MQTT broker. The only downside for me is that partially it relays on polling instead of being fully interrupt-driven.

I've seen a few discussions about adding an ISR callback, but it was never done. So here it is.

A few additional notes:
- ISR method should have IRAM_ATTR
`void IRAM_ATTR isrRadioMessage();`
- ISR should not block (it must be simple and fast)
- `radio.receiveDone()` should be called after the radio initialization

An example that demonstrates the usage:
```cpp
SPIClass spi;
RFM69 radio(RFM_CS, RFM_INT, RFM_HW, &spi);
EventGroupHandle_t eg;
SemaphoreHandle_t semaRadio;

#define EVENT_RADIO_MESSAGE (1 << 0)

void IRAM_ATTR isrRadioMessage()
{
    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
    xEventGroupSetBitsFromISR(eg, EVENT_RADIO_MESSAGE, &xHigherPriorityTaskWoken);
}

void taskReadRadioMessage(void *pvParameters)
{
    for (;;)
    {
        xEventGroupWaitBits(eg, EVENT_RADIO_MESSAGE, pdTRUE, pdTRUE, portMAX_DELAY);

        if (xSemaphoreTake(semaRadio, portMAX_DELAY) == pdTRUE)
        {
            if (radio.receiveDone())
            {
                Serial.printf("Received from node %d\n", radio.SENDERID);
                Serial.printf("Length: %d\n", radio.DATALEN);
                Serial.printf("RSSI: %d\n", radio.RSSI);

                // Do something with payload

                if (radio.ACKRequested())
                {
                    radio.sendACK();
                    Serial.printf("ACK sent to node %d\n", radio.SENDERID);
                }
            }
            xSemaphoreGive(semaRadio);
        }
    }
}

void setup()
{
  Serial.begin(115200);
  pinMode(RFM_INT, INPUT);

  eg = xEventGroupCreate();
  semaRadio = xSemaphoreCreateMutex();

  xTaskCreatePinnedToCore(taskReadRadioMessage, "radio", TaskStack10K, NULL, Priority1, NULL, Core1);

  spi.begin(M_SCK, M_MISO, M_MOSI, RFM_CS);
  radio.initialize(RF69_868MHZ, RADIO_NODE_ID, RADIO_NETWORK_ID);
  radio.encrypt(RADIO_ENCRYPTION_KEY);
  radio.setIsrCallback(isrRadioMessage);
  radio.receiveDone();
}

void loop()
{
}
```

Let me know if any additional fixes are required to merge this PR.
Thank you for the great library.